### PR TITLE
Experiment/hl oas

### DIFF
--- a/core/authentication/src/main/java/com/pluxity/authentication/security/JwtAuthenticationFilter.java
+++ b/core/authentication/src/main/java/com/pluxity/authentication/security/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -78,14 +79,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private boolean authenticationRequired(HttpServletRequest request) {
-        var path = request.getRequestURI();
-        NoAuthenticationPath[] values = NoAuthenticationPath.values();
-        for (NoAuthenticationPath value : values) {
-            if (path.matches("^/" + value.getPath() + ".*")) {
-                return false;
-            }
-        }
-
-        return true;
+        return Arrays.stream(NoAuthenticationPath.values())
+                .noneMatch(noAuthPath -> request.getRequestURI().contains(noAuthPath.getPath()));
     }
 }

--- a/core/authentication/src/main/java/com/pluxity/authentication/security/JwtAuthenticationFilter.java
+++ b/core/authentication/src/main/java/com/pluxity/authentication/security/JwtAuthenticationFilter.java
@@ -79,7 +79,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private boolean authenticationRequired(HttpServletRequest request) {
+        String path = request.getRequestURI();
         return Arrays.stream(NoAuthenticationPath.values())
-                .noneMatch(noAuthPath -> request.getRequestURI().contains(noAuthPath.getPath()));
+                .noneMatch(noAuthPath -> path.startsWith("/" + noAuthPath.getPath()));
     }
 }
+
+

--- a/core/authentication/src/main/java/com/pluxity/authentication/security/NoAuthenticationPath.java
+++ b/core/authentication/src/main/java/com/pluxity/authentication/security/NoAuthenticationPath.java
@@ -3,8 +3,8 @@ package com.pluxity.authentication.security;
 public enum NoAuthenticationPath {
     AUTH("auth"),
     ACTUATOR("actuator"),
-    APIDOC("api-docs"),
-    SWAGGER("swagger");
+    SWAGGER_UI("swagger-ui"),
+    API_DOCS("api-docs");
 
     private final String path;
 

--- a/project-a/build.gradle
+++ b/project-a/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     implementation project(':core:building')
     implementation project(':core:authentication')
 
+    // latest version of SpringDoc OpenAPI UI
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.1'
 }
 
 build {

--- a/project-a/src/main/java/com/pluxity/config/OpenAPIConfig.java
+++ b/project-a/src/main/java/com/pluxity/config/OpenAPIConfig.java
@@ -1,0 +1,21 @@
+package com.pluxity.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAPIConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Core Module API")
+                .version("v1.0")
+                .description("OAS Documentation");
+
+        return new OpenAPI()
+                .info(info);
+    }
+}

--- a/project-a/src/main/resources/application.yml
+++ b/project-a/src/main/resources/application.yml
@@ -31,3 +31,10 @@ logging:
     org: INFO
     com: DEBUG
     root: INFO
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+  api-docs:
+    path: /v3/api-docs
+  show-actuator: true

--- a/project-a/src/main/resources/application.yml
+++ b/project-a/src/main/resources/application.yml
@@ -36,5 +36,5 @@ springdoc:
   swagger-ui:
     path: /swagger-ui.html
   api-docs:
-    path: /v3/api-docs
+    path: /api-docs
   show-actuator: true


### PR DESCRIPTION
## 요약
인증 관련
- startwith로 비교하는거 contain으로 비교하는거로 바꿈

500 서버 에러
`java.lang.NoSuchMethodError: 'void org.springframework.web.method.ControllerAdviceBean.<init>(java.lang.Object)'`
-  이거는 openapi 버전이 안맞아서 발생. 최신버전으로 업데이트 완료
  

## 이슈 넘버 or 관련 링크
  `#1`

## 변경사항 🏗️  
요약 참고
- contains로 허용하는거는 보안 위협일거 같아서 request uri 
```
/swagger-ui/index.html
/swagger-ui/index.css
/swagger-ui/swagger-ui.css
/swagger-ui/swagger-ui-bundle.js
/swagger-ui/swagger-initializer.js
/swagger-ui/swagger-ui-standalone-preset.js
/swagger-ui/swagger-ui.css.map
/swagger-ui/favicon-32x32.png
/api-docs/swagger-config
/api-docs
```
위에거를 확인 후 swagger-ui랑 api-docs에 대해 startwith 체크하는 로직으로 변경함.
api-docs는 v3 붙어있는거 보기 싫어서 떼어냈음.

<!-- 변경 사항에 대해서 기재 필요 -->
### Checklist 📋
## 코드 변경 사항   
- [x] PR 설명에 변경 사항을 명확히 기재했습니다.  
- [ ] 테스트 계획에 따라 변경 사항을 테스트했습니다:
