### PR TITLE
Onboarding/step 2 user

### DIFF
--- a/common/src/main/kotlin/com/pluxity/global/config/CommonSecurityConfig.kt
+++ b/common/src/main/kotlin/com/pluxity/global/config/CommonSecurityConfig.kt
@@ -51,6 +51,7 @@ class CommonSecurityConfig(
                         "/api-docs/**",
                         "/swagger-config/**",
                         "/docs/**",
+                        "/api/v1/onboarding/**"
                     ).permitAll() // .requestMatchers("/admin/**").hasRole("ADMIN") // TODO: 구현 완료 시 적용
                     .requestMatchers("/auth/**")
                     .permitAll() // GET 외의 /auth/** 경로도 허용

--- a/common/src/main/kotlin/com/pluxity/user/repository/RoleRepository.kt
+++ b/common/src/main/kotlin/com/pluxity/user/repository/RoleRepository.kt
@@ -18,4 +18,6 @@ interface RoleRepository : JpaRepository<Role, Long> {
         ],
     )
     fun findByAuthIsNotOrderByCreatedAtDesc(auth: String): List<Role>
+
+    fun findByName(name: String): Role?
 }

--- a/common/src/test/kotlin/com/pluxity/user/entity/OnboardingUserTest.kt
+++ b/common/src/test/kotlin/com/pluxity/user/entity/OnboardingUserTest.kt
@@ -1,0 +1,46 @@
+package com.pluxity.user.entity
+
+import org.junit.jupiter.api.DisplayName
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class OnboardingUserTest {
+
+    @Test
+    @DisplayName("비밀번호 변경 시 password 필드가 변경 검증")
+    fun changePassword_Success() {
+        // given: 테스트할 User 준비
+        val user = User(
+            username = "testuser",
+            password = "oldPassword",
+            name = "테스트유저",
+            code = null
+        )
+
+        // when: 비밀번호 변경 실행
+        user.changePassword("newPassword")
+
+        // then: password가 변경되었는지 검증
+        assertThat(user.password).isEqualTo("newPassword")
+    }
+
+    @Test
+    @DisplayName("비밀번호 변경 시 lastPasswordChangeDate가 현재 시간으로 갱신")
+    fun changePassword_UpdatesLastChangeDate() {
+        // given
+        val user = User(
+            username = "testuser",
+            password = "oldPassword",
+            name = "테스트유저",
+            code = null
+        )
+        val beforeChangeDate = user.lastPasswordChangeDate
+
+        // when
+        Thread.sleep(1000)
+        user.changePassword("newPassword")
+
+        // then
+        assertThat(user.lastPasswordChangeDate).isAfter(beforeChangeDate)
+    }
+}

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
@@ -1,7 +1,15 @@
 package com.pluxity.onboarding
 
 import com.pluxity.global.annotation.ResponseCreated
+import com.pluxity.global.response.ErrorResponseBody
 import com.pluxity.onboarding.dto.AdminUserCreateRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
@@ -11,12 +19,53 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/v1/onboarding")
+@Tag(name = "Onboarding Controller", description = "온보딩 API")
 class OnboardingController(
     private val service: OnboardingService
 ) {
+    @Operation(summary = "관리자 사용자 생성", description = "새로운 관리자 계정을 생성합니다")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "관리자 사용자 생성 성공",
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (validation 실패)",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "이미 존재하는 사용자명",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
     @PostMapping("/users")
     @ResponseCreated(path = "/api/v1/onboarding/users/{id}")
     fun createAdminUser(
+        @Parameter(description = "관리자 사용자 생성 정보", required = true)
         @RequestBody @Valid request: AdminUserCreateRequest
     ): ResponseEntity<Long> = ResponseEntity.ok(service.createAdminUser(request))
 }

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
@@ -1,5 +1,6 @@
 package com.pluxity.onboarding
 
+import com.pluxity.global.annotation.ResponseCreated
 import com.pluxity.onboarding.dto.AdminUserCreateRequest
 import jakarta.validation.Valid
 import org.springframework.http.ResponseEntity
@@ -14,6 +15,7 @@ class OnboardingController(
     private val service: OnboardingService
 ) {
     @PostMapping("/users")
+    @ResponseCreated(path = "/api/v1/onboarding/users/{id}")
     fun createAdminUser(
         @RequestBody @Valid request: AdminUserCreateRequest
     ): ResponseEntity<Long> = ResponseEntity.ok(service.createAdminUser(request))

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
@@ -1,0 +1,20 @@
+package com.pluxity.onboarding
+
+import com.pluxity.onboarding.dto.AdminUserCreateRequest
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/onboarding")
+class OnboardingController(
+    private val service: OnboardingService
+) {
+    @PostMapping("/users")
+    fun createAdminUser(
+        @RequestBody @Valid request: AdminUserCreateRequest
+    ): ResponseEntity<Long> = ResponseEntity.ok(service.createAdminUser(request))
+}

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingService.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingService.kt
@@ -1,0 +1,39 @@
+package com.pluxity.onboarding
+
+import com.pluxity.onboarding.dto.AdminUserCreateRequest
+import com.pluxity.user.entity.Role
+import com.pluxity.user.entity.RoleType
+import com.pluxity.user.entity.User
+import com.pluxity.user.repository.RoleRepository
+import com.pluxity.user.repository.UserRepository
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OnboardingService(
+    private val roleRepository: RoleRepository,
+    private val userRepository: UserRepository,
+    private val passwordEncoder: PasswordEncoder
+) {
+
+    @Transactional
+    fun createAdminUser(request: AdminUserCreateRequest): Long? {
+        val user =
+            User(
+                username = request.username,
+                password = passwordEncoder.encode(request.password),
+                name = request.name,
+                code = null
+            )
+
+        val role = roleRepository.findByName(RoleType.USER.roleName)
+            ?: roleRepository.save(Role(name = RoleType.ADMIN.roleName, description = "test role desc"))
+
+        user.addRole(role)
+
+        val createUser: User = userRepository.save(user)
+
+        return createUser.id
+    }
+}

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingService.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingService.kt
@@ -27,7 +27,7 @@ class OnboardingService(
                 code = null
             )
 
-        val role = roleRepository.findByName(RoleType.USER.roleName)
+        val role = roleRepository.findByName(RoleType.ADMIN.roleName)
             ?: roleRepository.save(Role(name = RoleType.ADMIN.roleName, description = "test role desc"))
 
         user.addRole(role)

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingService.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingService.kt
@@ -18,7 +18,7 @@ class OnboardingService(
 ) {
 
     @Transactional
-    fun createAdminUser(request: AdminUserCreateRequest): Long? {
+    fun createAdminUser(request: AdminUserCreateRequest): Long {
         val user =
             User(
                 username = request.username,
@@ -32,8 +32,6 @@ class OnboardingService(
 
         user.addRole(role)
 
-        val createUser: User = userRepository.save(user)
-
-        return createUser.id
+        return userRepository.save(user).id!!
     }
 }

--- a/core/src/main/kotlin/com/pluxity/onboarding/dto/AdminUserCreateRequest.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/dto/AdminUserCreateRequest.kt
@@ -1,7 +1,23 @@
 package com.pluxity.onboarding.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
 data class AdminUserCreateRequest (
+
+    @field:Schema(description = "사용자 이름", example = "admin123", minLength = 3, maxLength = 20)
+    @field:NotBlank
+    @field:Size(min = 3, max = 20)
     val username: String,
+
+    @field:Schema(description = "비밀번호", example = "SecurePass123!", minLength = 8)
+    @field:NotBlank
+    @field:Size(min = 8, max = 30)
     val password: String,
+
+    @field:Schema(description = "이름", example = "name")
+    @field:NotBlank(message = "이름은 필수 입니다.")
+    @field:Size(max = 20, message = "이름은 최대 20자까지 입력 가능합니다.")
     val name: String
 )

--- a/core/src/main/kotlin/com/pluxity/onboarding/dto/AdminUserCreateRequest.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/dto/AdminUserCreateRequest.kt
@@ -1,0 +1,7 @@
+package com.pluxity.onboarding.dto
+
+data class AdminUserCreateRequest (
+    val username: String,
+    val password: String,
+    val name: String
+)


### PR DESCRIPTION
## 요약
ADMIN 권한을 가진 사용자를 생성하는 온보딩 API 구현

## 이슈 넘버 or 관련 링크
https://github.com/pluxity/plug-platform-api/blob/onboarding/main/onboarding/02_USER_DOMAIN.md

## 주요 변경사항

### 1. 온보딩 API 구현
- **Endpoint:** `POST /api/v1/onboarding/users`
- **기능:** ADMIN 롤을 가진 시스템 관리자 생성

### 2. RoleRepository 확장
- `findByName(name: String): Role?` 메서드 추가

### 3. Security 설정
- `/api/v1/onboarding/**` 경로만 인증 제외

### 4. 단위 테스트 추가
- `UserTest.kt`: User 엔티티의 `changePassword()` 로직 검증


Role 엔티티의 auth와 name 필드가 혼란스러워서 분석해봤습니다.


- 실제 권한 체크는 role.name으로 수행 (User.canAccess() 참고)
``` kotlin
fun canAccess(
        resourceName: String,
        resourceId: String,
    ): Boolean =
        userRoles.any { it.role.name == RoleType.ADMIN.roleName } ||
            userRoles.any { it.role.hasPermissionFor(resourceName, resourceId) }
```

- RoleRepository에서는 auth로 조회하는 로직 존재
``` kotlin
    @EntityGraph(
        attributePaths = [
            "userRoles.user", "userRoles.role", "rolePermissions.permissionGroup.permissions",
        ],
    )
    fun findByAuthIsNotOrderByCreatedAtDesc(auth: String): List<Role>
```
- auth 필드는 기본값 "USER"로 고정되어 있고 변경하는 로직이 없음
``` kotlin
var auth: String? = "USER"
```

=> name을 기반으로 권한 체크하는것같아 이름으로 조회하도록 했습니다.
``` kotlin
val role = roleRepository.findByName(RoleType.ADMIN.roleName)
            ?: roleRepository.save(Role(name = RoleType.ADMIN.roleName, description = "test role desc"))
```


