### PR TITLE
Onboarding/Step 4 device

### DIFF
--- a/common/src/main/kotlin/com/pluxity/device/entity/Device.kt
+++ b/common/src/main/kotlin/com/pluxity/device/entity/Device.kt
@@ -34,6 +34,11 @@ class Device(
     var companyType: DeviceCompanyType,
 ) : BaseEntity(),
     Permissible {
+
+    init {
+        category?.addDevice(this)
+    }
+
     fun changeFeature(feature: Feature?) {
         this.feature = feature
     }

--- a/common/src/main/kotlin/com/pluxity/device/entity/DeviceCategory.kt
+++ b/common/src/main/kotlin/com/pluxity/device/entity/DeviceCategory.kt
@@ -4,19 +4,12 @@ import com.pluxity.category.entity.Category
 import com.pluxity.permission.ResourceType
 import com.pluxity.user.entity.Permissible
 import jakarta.persistence.Column
-import jakarta.persistence.DiscriminatorColumn
-import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
-import jakarta.persistence.Inheritance
-import jakarta.persistence.InheritanceType
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 
 @Entity
 @Table(name = "device_category")
-@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
-@DiscriminatorColumn(name = "CATEGORY_TYPE")
-@DiscriminatorValue("DEVICE_BASE")
 class DeviceCategory(
     var categoryName: String = "",
     @Column(name = "icon_file_id")

--- a/common/src/main/kotlin/com/pluxity/device/entity/DeviceCategory.kt
+++ b/common/src/main/kotlin/com/pluxity/device/entity/DeviceCategory.kt
@@ -28,7 +28,7 @@ class DeviceCategory(
     }
 
     fun removeDevice(device: Device?) {
-        device?.let { devices.remove(it) }
+        device?.let { devices.removeIf { it.id == device.id } }
     }
 
     fun assignToRootPreservingEntity() {

--- a/common/src/main/kotlin/com/pluxity/device/service/DeviceService.kt
+++ b/common/src/main/kotlin/com/pluxity/device/service/DeviceService.kt
@@ -37,9 +37,10 @@ class DeviceService(
             deviceType = request.deviceType,
             companyType = request.companyType,
         )
+        val savedDevice = deviceRepository.save(device)
+        savedDevice.changeCategory(category)
 
-        device.changeCategory(category)
-        return deviceRepository.save(device).id
+        return savedDevice.id
     }
 
     @Transactional(readOnly = true)

--- a/common/src/main/kotlin/com/pluxity/device/service/DeviceService.kt
+++ b/common/src/main/kotlin/com/pluxity/device/service/DeviceService.kt
@@ -29,16 +29,17 @@ class DeviceService(
     @Transactional
     fun save(request: DeviceCreateRequest): String {
         val category = request.categoryId?.let { deviceCategoryService.findById(request.categoryId) }
-        return deviceRepository
-            .save(
-                Device(
-                    id = request.id,
-                    name = request.name,
-                    category = category,
-                    deviceType = request.deviceType,
-                    companyType = request.companyType,
-                ),
-            ).id
+
+        val device = Device(
+            id = request.id,
+            name = request.name,
+            category = null,
+            deviceType = request.deviceType,
+            companyType = request.companyType,
+        )
+
+        device.changeCategory(category)
+        return deviceRepository.save(device).id
     }
 
     @Transactional(readOnly = true)

--- a/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep4DeviceFacilityTest.kt
+++ b/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep4DeviceFacilityTest.kt
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
 
 /**
@@ -132,7 +133,7 @@ class OnboardingStep4DeviceFacilityTest @Autowired constructor(
         deviceRepository.flush()
 
         // 초기 상태 확인
-        val device = deviceRepository.findById(deviceId).orElse(null)!!
+        val device = deviceRepository.findByIdOrNull(deviceId)!!
         val oldCategory = device.category!!
         val categoryB = deviceCategoryService.findById(categoryBId)
 
@@ -177,7 +178,7 @@ class OnboardingStep4DeviceFacilityTest @Autowired constructor(
 
 
         // when
-        val device = deviceRepository.findByIdOrNullCustom(deviceId)!!
+        val device = deviceRepository.findByIdOrNull(deviceId)!!
         device.changeCategory(null)
         deviceRepository.flush()
 

--- a/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep4DeviceFacilityTest.kt
+++ b/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep4DeviceFacilityTest.kt
@@ -1,0 +1,194 @@
+package com.pluxity.onboarding
+
+import com.pluxity.building.BuildingService
+import com.pluxity.building.dto.BuildingCreateRequest
+import com.pluxity.device.dto.DeviceCategoryRequest
+import com.pluxity.device.dto.DeviceCreateRequest
+import com.pluxity.device.entity.DeviceCompanyType
+import com.pluxity.device.entity.DeviceType
+import com.pluxity.device.repository.DeviceRepository
+import com.pluxity.device.service.DeviceCategoryService
+import com.pluxity.device.service.DeviceService
+import com.pluxity.facility.dto.FacilityCreateRequest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 온보딩 4단계: 장비 및 시설 도메인 테스트
+ *
+ * 과제 1: Building 및 Device 생성
+ * 과제 2: Device 카테고리 변경 시 양방향 관계 검증
+ *
+ */
+
+@SpringBootTest
+@Transactional
+class OnboardingStep4DeviceFacilityTest @Autowired constructor(
+    private val deviceService: DeviceService,
+    private val deviceRepository: DeviceRepository,
+    private val buildingService: BuildingService,
+    private val deviceCategoryService: DeviceCategoryService,
+) {
+    private var testBuildingId: Long = 0
+    private var categoryAId: Long = 0
+    private var categoryBId: Long = 0
+
+    @BeforeEach
+    fun setUp() {
+        testBuildingId = buildingService.save(
+            BuildingCreateRequest(
+                FacilityCreateRequest(
+                    name = "테스트 건물",
+                    code = "TEST-CODE",
+                    description = "온보딩 테스트용 건물",
+                    drawingFileId = null,
+                    thumbnailFileId = null,
+                    lon = null,
+                    lat = null,
+                    locationMeta = null
+                ),
+                emptyList()
+            )
+        )
+
+        categoryAId = deviceCategoryService.create(
+            DeviceCategoryRequest(
+                name = "카테고리A",
+                parentId = null,
+                thumbnailFileId = null
+            )
+        )
+
+        categoryBId = deviceCategoryService.create(
+            DeviceCategoryRequest(
+                name = "카테고리B",
+                parentId = null,
+                thumbnailFileId = null
+            )
+        )
+    }
+
+    @Test
+    @DisplayName("과제 1: Building 생성 및 저장 성공")
+    fun createBuilding_success() {
+        // then
+        val building = buildingService.findById(testBuildingId)
+
+        assertThat(building.facility.id).isEqualTo(testBuildingId)
+        assertThat(building.facility.name).isEqualTo("테스트 건물")
+        assertThat(building.facility.code).isEqualTo("TEST-CODE")
+        assertThat(building.facility.description).isEqualTo("온보딩 테스트용 건물")
+    }
+
+    @Test
+    @DisplayName("과제 1: Device 생성 및 DeviceCategory 할당 성공")
+    fun createDevice_withCategory_success() {
+        // given
+        val deviceId = "DEVICE-01"
+        val request = DeviceCreateRequest(
+            id = deviceId,
+            name = "TEST-DEVICE",
+            categoryId = categoryAId,
+            companyType = DeviceCompanyType.DAWONDNS,
+            deviceType = DeviceType.TEMP_HUM
+        )
+
+        // when
+        val savedDeviceId = deviceService.save(request)
+
+        // then
+        val device = deviceRepository.findByIdOrNullCustom(deviceId)!!
+
+        val categoryA = deviceCategoryService.findById(categoryAId)
+
+        assertThat(categoryA.devices).anyMatch { it.id == deviceId }
+        assertThat(savedDeviceId).isEqualTo(deviceId)
+        assertThat(device.name).isEqualTo("TEST-DEVICE")
+        assertThat(device.category).isNotNull
+        assertThat(device.category?.id).isEqualTo(categoryAId)
+        assertThat(device.category?.name).isEqualTo("카테고리A")
+    }
+
+    @Test
+    @DisplayName("과제 2: Device 카테고리 변경 시 양방향 관계 정리 검증")
+    fun changeDeviceCategory_verifyBidirectionalRelations() {
+        // given
+        val deviceId = deviceService.save(
+            DeviceCreateRequest(
+                id = "테스트 ID",
+                name = "테스트 장비",
+                categoryId = categoryAId,
+                companyType = DeviceCompanyType.DAWONDNS,
+                deviceType = DeviceType.TEMP_HUM
+            )
+        )
+
+        // flush로 DB 반영
+        deviceRepository.flush()
+
+        // 초기 상태 확인
+        val device = deviceRepository.findById(deviceId).orElse(null)!!
+        val oldCategory = device.category!!
+        val categoryB = deviceCategoryService.findById(categoryBId)
+
+        assertThat(oldCategory.devices).hasSize(1)
+        assertThat(oldCategory.devices.first().id).isEqualTo(deviceId)
+        assertThat(categoryB.devices).isEmpty()
+
+        // when
+        device.changeCategory(categoryB)
+
+        deviceRepository.flush()
+
+        // then - 같은 인스턴스로 검증
+        assertThat(oldCategory.devices)
+            .describedAs("CategoryA의 장비 목록에 Device가 없어야 함")
+            .noneMatch { it.id == deviceId }
+
+        assertThat(categoryB.devices)
+            .describedAs("CategoryB의 장비 목록에 Device가 있어야 함")
+            .anyMatch { it.id == deviceId }
+
+        assertThat(device.category?.id).isEqualTo(categoryBId)
+    }
+
+    @Test
+    @DisplayName("과제 2: Device 카테고리를 null로 변경 시 이전 카테고리에서 제거됨")
+    fun changeDeviceCategory_toNull_removesFromPreviousCategory() {
+        // given
+        val deviceId = "DEVICE-NULL-TEST"
+        deviceService.save(
+            DeviceCreateRequest(
+                id = deviceId,
+                name = "카테고리 제거 테스트 장비",
+                categoryId = categoryAId,
+                companyType = DeviceCompanyType.DAWONDNS,
+                deviceType = DeviceType.TEMP_HUM
+            )
+        )
+
+        val categoryA = deviceCategoryService.findById(categoryAId)
+        assertThat(categoryA.devices).anyMatch { it.id == deviceId }
+
+
+        // when
+        val device = deviceRepository.findByIdOrNullCustom(deviceId)!!
+        device.changeCategory(null)
+        deviceRepository.flush()
+
+        // then
+        val updatedCategoryA = deviceCategoryService.findById(categoryAId)
+
+        assertThat(updatedCategoryA.devices)
+            .describedAs("CategoryA에서 Device가 제거되어야 함")
+            .noneMatch { it.id == deviceId }
+
+        assertThat(device.category).isNull()
+
+    }
+}


### PR DESCRIPTION
## 요약
장비 및 시설 도메인 학습
- Category의 parent, children 계층 구조
- Facility의 JPA 상속 전략(InheritanceType.JOINED)
- Device와 DeviceCategory 연관관계


## 이슈 넘버 or 관련 링크
https://github.com/pluxity/plug-platform-api/blob/onboarding/main/onboarding/04_DEVICE_FACILITY.md  

## 변경사항 🏗️  
- DeviceCategory의 JPA 상속 전략 제거
 => parent/children 계층 구조만으로 카테고리 관리가 가능하므로 JPA 상속 전략 제거
- Device 생성 시 Cateogry 연관관계 동기화
 => save시 changeCategory() 실행

### merge vs persist

Device는 생성 시 ID를 직접 할당해 생성하고있습니다.
JPA에서 `save()` 는 ID의 유무에 따라 다르게 동작한다고 합니다.
- ID가 있을 경우 : merge() => 새로운 인스턴스 생성 후 반환
- ID가 없을 경우 : persist() => 원본 인스턴스 영속화

#### 문제 상황

**작성한 코드:**
```kotlin
// DeviceService.save()
val device = Device(id = "123", ...)        // 인스턴스 A 생성
device.changeCategory(category)              // category.devices에 A 추가
deviceRepository.save(device)                // merge() 호출 → 인스턴스 B 반환 (미사용)

// 테스트 코드
deviceService.save(DeviceCreateRequest(id="테스트 ID",...))
val device = deviceRepository.findById(deviceId).orElse(null)!!  // 인스턴스 B
val oldCategory = device.category!!                               // oldCategory.devices에는 A
val categoryB = deviceCategoryService.findById(categoryBId)

device.changeCategory(categoryB)  
// 실패문제:
- removeDevice()에서 파라미터로 받은 device는 인스턴스 B
- oldCategory.devices에 담긴 device는 인스턴스 A
- devices.remove(it)는 객체 참조를 비교하므로 삭제 실패
- 결과: 양방향 관계가 끊기지 않음
```
#### 해결 방법

**1. DeviceService: 영속화 후 관계 설정**
```kotlin
val device = Device(id = request.id, ...)
val savedDevice = deviceRepository.save(device)  // merge()로 인스턴스 B 획득
savedDevice.changeCategory(category)              // B로 관계 설정
```

**2. DeviceCategory: ID 기반 비교**
```kotlin
fun removeDevice(device: Device?) {
    device?.let { devices.removeIf { it.id == device.id } }  // 객체 비교 → ID 비교
}
```

