### PR TITLE
Onboarding/step 8 complex

### DIFF
--- a/common/src/main/kotlin/com/pluxity/global/constant/ErrorCode.kt
+++ b/common/src/main/kotlin/com/pluxity/global/constant/ErrorCode.kt
@@ -103,6 +103,8 @@ enum class ErrorCode(
     NOT_FOUND_ASSIGN_DEVICE_CATEGORY(HttpStatus.NOT_FOUND, "ID가 %s인 디바이스에 할당된 카테고리를 찾을 수 없습니다."),
 
     INVALID_RESOURCE_IDS_INCLUDED(HttpStatus.BAD_REQUEST, "요청한 리소스 ID %s 는 유효하지 않습니다."),
+
+    ALREADY_CONNECTED_LINE(HttpStatus.BAD_REQUEST, "이미 연결된 노선있습니다."),
     ;
 
     override fun getHttpStatus(): HttpStatus = httpStatus

--- a/common/src/main/kotlin/com/pluxity/global/constant/ErrorCode.kt
+++ b/common/src/main/kotlin/com/pluxity/global/constant/ErrorCode.kt
@@ -104,7 +104,7 @@ enum class ErrorCode(
 
     INVALID_RESOURCE_IDS_INCLUDED(HttpStatus.BAD_REQUEST, "요청한 리소스 ID %s 는 유효하지 않습니다."),
 
-    ALREADY_CONNECTED_LINE(HttpStatus.BAD_REQUEST, "이미 연결된 노선있습니다."),
+    ALREADY_CONNECTED_LINE(HttpStatus.BAD_REQUEST, "ID가 %s 인 역에 이미 연결된 노선이 있습니다."),
     ;
 
     override fun getHttpStatus(): HttpStatus = httpStatus

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
@@ -332,12 +332,12 @@ class OnboardingController(
             ),
         ],
     )
-    @DeleteMapping("station/{id}/lines")
+    @DeleteMapping("stations/{id}/{lineId}")
     fun deleteStationLine(
         @Parameter(description = "역 ID", required = true, example = "1")
         @PathVariable id: Long,
         @Parameter(description = "삭제할 노선 ID", required = true, example = "169")
-        @RequestBody lineId: Long,
+        @PathVariable lineId: Long,
     ): ResponseEntity<Void?> {
         lineService.deleteStationLine(id, lineId)
         return ResponseEntity.noContent().build<Void?>()
@@ -350,7 +350,7 @@ class OnboardingController(
     @ApiResponses(
         value = [
             ApiResponse(
-                responseCode = "200",
+                responseCode = "204",
                 description = "환승역 조회 성공",
                 content = [
                     Content(
@@ -371,6 +371,6 @@ class OnboardingController(
             ),
         ],
     )
-    @GetMapping("/station/two-line")
+    @GetMapping("/stations/transfer")
     fun findStationTwoLine(): ResponseEntity<List<OnboardingStationResponse>> = ResponseEntity.ok(lineService.findStationTwoLine())
 }

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
@@ -5,8 +5,10 @@ import com.pluxity.global.response.ErrorResponseBody
 import com.pluxity.onboarding.dto.AdminUserCreateRequest
 import com.pluxity.onboarding.dto.OnboardingFacilityRequest
 import com.pluxity.onboarding.dto.OnboardingFileResponse
+import com.pluxity.onboarding.dto.OnboardingStationResponse
 import com.pluxity.onboarding.service.OnboardingBuildingService
 import com.pluxity.onboarding.service.OnboardingFileService
+import com.pluxity.onboarding.service.OnboardingLineService
 import com.pluxity.onboarding.service.OnboardingUserService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -35,6 +37,7 @@ class OnboardingController(
     private val userService: OnboardingUserService,
     private val fileService: OnboardingFileService,
     private val buildingService: OnboardingBuildingService,
+    private val lineService: OnboardingLineService,
     private val collector: OnboardingCollector,
 ) {
     @Operation(summary = "관리자 사용자 생성", description = "새로운 관리자 계정을 생성합니다")
@@ -245,4 +248,129 @@ class OnboardingController(
     )
     @GetMapping("/collect")
     suspend fun collectData(): ResponseEntity<List<MockData>> = ResponseEntity.ok(collector.collectData())
+
+    @Operation(
+        summary = "역에 노선 추가",
+        description = "특정 역에 여러 노선을 연결합니다. 이미 연결된 노선이 있으면 예외가 발생합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "노선 연결 성공",
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "역 또는 노선을 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "이미 연결된 노선이 있음",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    @PostMapping("/stations/{id}/lines")
+    @ResponseCreated(path = "/api/v1/onboarding/stations/{id}/lines")
+    fun putStationLine(
+        @Parameter(description = "역 ID", required = true, example = "1")
+        @PathVariable id: Long,
+        @Parameter(description = "연결할 노선 ID 목록", required = true)
+        @RequestBody lineIds: List<Long>,
+    ): ResponseEntity<Long> = ResponseEntity.ok(lineService.putStationLine(stationId = id, lineIds))
+
+    @Operation(
+        summary = "역에서 노선 삭제",
+        description = "특정 역에서 노선 연결을 제거합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "노선 연결 삭제 성공",
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "역, 노선 또는 연결 정보를 찾을 수 없음",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    @DeleteMapping("station/{id}/lines")
+    fun deleteStationLine(
+        @Parameter(description = "역 ID", required = true, example = "1")
+        @PathVariable id: Long,
+        @Parameter(description = "삭제할 노선 ID", required = true, example = "169")
+        @RequestBody lineId: Long,
+    ): ResponseEntity<Void?> {
+        lineService.deleteStationLine(id, lineId)
+        return ResponseEntity.noContent().build<Void?>()
+    }
+
+    @Operation(
+        summary = "환승역 조회",
+        description = "2개 이상의 노선이 지나가는 역(환승역) 목록을 조회합니다.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "환승역 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = OnboardingStationResponse::class),
+                    ),
+                ],
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponseBody::class),
+                    ),
+                ],
+            ),
+        ],
+    )
+    @GetMapping("/station/two-line")
+    fun findStationTwoLine(): ResponseEntity<List<OnboardingStationResponse>> = ResponseEntity.ok(lineService.findStationTwoLine())
 }

--- a/core/src/main/kotlin/com/pluxity/onboarding/dto/OnboardingLineResponse.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/dto/OnboardingLineResponse.kt
@@ -1,0 +1,5 @@
+package com.pluxity.onboarding.dto
+
+data class OnboardingLineResponse(
+    val name: String,
+)

--- a/core/src/main/kotlin/com/pluxity/onboarding/dto/OnboardingStationResponse.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/dto/OnboardingStationResponse.kt
@@ -1,0 +1,6 @@
+package com.pluxity.onboarding.dto
+
+data class OnboardingStationResponse(
+    val name: String,
+    val lines: List<OnboardingLineResponse>,
+)

--- a/core/src/main/kotlin/com/pluxity/onboarding/service/OnboardingLineService.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/service/OnboardingLineService.kt
@@ -30,23 +30,23 @@ class OnboardingLineService(
 
         val foundLines = lineRepository.findAllById(lineIds)
         if (foundLines.size != lineIds.size) {
-            throw CustomException(ErrorCode.NOT_FOUND_LINE)
+            val foundLineIds = foundLines.mapNotNull { it.id }.toSet()
+            val notFoundIds = lineIds.filterNot { foundLineIds.contains(it) }
+            throw CustomException(ErrorCode.NOT_FOUND_LINE, notFoundIds.joinToString())
         }
 
         if (stationLineRepository.existsByStationAndLineIn(foundStation, foundLines)) {
-            throw CustomException(ErrorCode.ALREADY_CONNECTED_LINE, "이미 연결된 노선있습니다.")
+            throw CustomException(ErrorCode.ALREADY_CONNECTED_LINE, foundStation.id)
         }
 
         foundLines.forEach { line ->
-            stationLineRepository
-                .save(
-                    StationLine(
-                        station = foundStation,
-                        line = line,
-                    ),
-                ).let {
-                    line.addStationLine(it)
-                }
+            val stationLine =
+                StationLine(
+                    station = foundStation,
+                    line = line,
+                )
+            stationLineRepository.save(stationLine)
+            line.addStationLine(stationLine)
         }
 
         return stationId
@@ -75,22 +75,20 @@ class OnboardingLineService(
     // 환승역 조회
     @Transactional(readOnly = true)
     fun findStationTwoLine(): List<OnboardingStationResponse> {
-        val result = mutableListOf<OnboardingStationResponse>()
-
         val stations = stationLineRepository.findStationIdsWithMultipleLines()
+        if (stations.isEmpty()) {
+            return emptyList()
+        }
+
         val stationLines = stationLineRepository.findByStationInWithLines(stations)
 
-        stationLines
-            .groupBy { it.station.id }
-            .map { (stationId, lines) ->
-                val station = lines.first().station
-                result.add(
-                    OnboardingStationResponse(
-                        name = station.name,
-                        lines = lines.map { OnboardingLineResponse(it.line.name!!) },
-                    ),
+        return stationLines
+            .groupBy { it.station }
+            .map { (station, lines) ->
+                OnboardingStationResponse(
+                    name = station.name,
+                    lines = lines.map { OnboardingLineResponse(it.line.name!!) },
                 )
             }
-        return result
     }
 }

--- a/core/src/main/kotlin/com/pluxity/onboarding/service/OnboardingLineService.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/service/OnboardingLineService.kt
@@ -1,0 +1,96 @@
+package com.pluxity.onboarding.service
+
+import com.pluxity.global.constant.ErrorCode
+import com.pluxity.global.exception.CustomException
+import com.pluxity.onboarding.dto.OnboardingLineResponse
+import com.pluxity.onboarding.dto.OnboardingStationResponse
+import com.pluxity.station.LineRepository
+import com.pluxity.station.StationLine
+import com.pluxity.station.StationLineRepository
+import com.pluxity.station.StationRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class OnboardingLineService(
+    private val lineRepository: LineRepository,
+    private val stationLineRepository: StationLineRepository,
+    private val stationRepository: StationRepository,
+) {
+    // station에 line 추가
+    @Transactional
+    fun putStationLine(
+        stationId: Long,
+        lineIds: List<Long>,
+    ): Long {
+        val foundStation =
+            stationRepository.findByIdOrNull(stationId)
+                ?: throw CustomException(ErrorCode.NOT_FOUND_STATION, stationId)
+
+        val foundLines = lineRepository.findAllById(lineIds)
+        if (foundLines.size != lineIds.size) {
+            throw CustomException(ErrorCode.NOT_FOUND_LINE)
+        }
+
+        if (stationLineRepository.existsByStationAndLineIn(foundStation, foundLines)) {
+            throw CustomException(ErrorCode.ALREADY_CONNECTED_LINE, "이미 연결된 노선있습니다.")
+        }
+
+        foundLines.forEach { line ->
+            stationLineRepository
+                .save(
+                    StationLine(
+                        station = foundStation,
+                        line = line,
+                    ),
+                ).let {
+                    line.addStationLine(it)
+                }
+        }
+
+        return stationId
+    }
+
+    // station에 line 삭제
+    @Transactional
+    fun deleteStationLine(
+        stationId: Long,
+        lineId: Long,
+    ) {
+        val foundStation =
+            stationRepository.findByIdOrNull(stationId)
+                ?: throw CustomException(ErrorCode.NOT_FOUND_STATION, stationId)
+
+        val foundLine =
+            lineRepository.findByIdOrNull(lineId)
+                ?: throw CustomException(ErrorCode.NOT_FOUND_LINE, lineId)
+
+        val deletedCount = stationLineRepository.deleteByStationAndLine(foundStation, foundLine)
+        if (deletedCount == 0) {
+            throw CustomException(ErrorCode.NOT_FOUND_STATION_LINE)
+        }
+    }
+
+    // 환승역 조회
+    @Transactional(readOnly = true)
+    fun findStationTwoLine(): List<OnboardingStationResponse> {
+        val result = mutableListOf<OnboardingStationResponse>()
+
+        val stations = stationLineRepository.findStationIdsWithMultipleLines()
+        val stationLines = stationLineRepository.findByStationInWithLines(stations)
+
+        stationLines
+            .groupBy { it.station.id }
+            .map { (stationId, lines) ->
+                val station = lines.first().station
+                result.add(
+                    OnboardingStationResponse(
+                        name = station.name,
+                        lines = lines.map { OnboardingLineResponse(it.line.name!!) },
+                    ),
+                )
+            }
+        return result
+    }
+}

--- a/core/src/main/kotlin/com/pluxity/station/StationLineRepository.kt
+++ b/core/src/main/kotlin/com/pluxity/station/StationLineRepository.kt
@@ -1,6 +1,7 @@
 package com.pluxity.station
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface StationLineRepository : JpaRepository<StationLine, Long> {
     fun findByStationOrderByCreatedAtDesc(station: Station): List<StationLine>
@@ -18,4 +19,35 @@ interface StationLineRepository : JpaRepository<StationLine, Long> {
         station: Station,
         line: Line,
     ): StationLine?
+
+    @Query(
+        """
+        select sl.station
+        from StationLine sl
+        group by sl.station
+        having count(distinct sl.line.id) > 1
+    """,
+    )
+    fun findStationIdsWithMultipleLines(): List<Station>
+
+    @Query(
+        """
+        select sl
+        from StationLine sl
+        join fetch sl.station s
+        join fetch sl.line l
+        where s in :stations
+    """,
+    )
+    fun findByStationInWithLines(stations: List<Station>): List<StationLine>
+
+    fun existsByStationAndLineIn(
+        station: Station,
+        lines: List<Line>,
+    ): Boolean
+
+    fun deleteByStationAndLine(
+        station: Station,
+        line: Line,
+    ): Int
 }

--- a/core/src/main/kotlin/com/pluxity/station/StationLineRepository.kt
+++ b/core/src/main/kotlin/com/pluxity/station/StationLineRepository.kt
@@ -34,9 +34,7 @@ interface StationLineRepository : JpaRepository<StationLine, Long> {
         """
         select sl
         from StationLine sl
-        join fetch sl.station s
-        join fetch sl.line l
-        where s in :stations
+        where sl.station in :stations
     """,
     )
     fun findByStationInWithLines(stations: List<Station>): List<StationLine>

--- a/core/src/main/kotlin/com/pluxity/station/StationLineRepository.kt
+++ b/core/src/main/kotlin/com/pluxity/station/StationLineRepository.kt
@@ -51,5 +51,24 @@ interface StationLineRepository : JpaRepository<StationLine, Long> {
         line: Line,
     ): Int
 
+    /**
+     *  test용
+     */
     fun findByStation(station: Station): List<StationLine>
+
+    fun existsByStationId(stationId: Long): Boolean
+
+    fun existsByStation(station: Station): Boolean
+
+    fun findByStationId(stationId: Long): List<StationLine>
+
+    @Query(
+        """
+        select sl
+        from StationLine sl
+        join fetch sl.station s
+        where s.id = :stationId
+    """,
+    )
+    fun findByStationIdWithQuery(stationId: Long): List<StationLine>
 }

--- a/core/src/main/kotlin/com/pluxity/station/StationLineRepository.kt
+++ b/core/src/main/kotlin/com/pluxity/station/StationLineRepository.kt
@@ -50,4 +50,6 @@ interface StationLineRepository : JpaRepository<StationLine, Long> {
         station: Station,
         line: Line,
     ): Int
+
+    fun findByStation(station: Station): List<StationLine>
 }

--- a/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep8ComplexDomainTest.kt
+++ b/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep8ComplexDomainTest.kt
@@ -1,0 +1,194 @@
+package com.pluxity.onboarding
+
+import com.pluxity.global.exception.CustomException
+import com.pluxity.onboarding.service.OnboardingLineService
+import com.pluxity.station.Line
+import com.pluxity.station.LineRepository
+import com.pluxity.station.Station
+import com.pluxity.station.StationLineRepository
+import com.pluxity.station.StationRepository
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@Transactional
+class OnboardingStep8ComplexDomainTest
+    @Autowired
+    constructor(
+        private val onboardingLineService: OnboardingLineService,
+        private val stationRepository: StationRepository,
+        private val lineRepository: LineRepository,
+        private val stationLineRepository: StationLineRepository,
+        private val entityManager: EntityManager,
+    ) {
+        private lateinit var station1: Station
+        private lateinit var station2: Station
+        private lateinit var line1: Line
+        private lateinit var line2: Line
+        private lateinit var line3: Line
+
+        @BeforeEach
+        fun setUp() {
+            // 테스트 데이터 준비
+            station1 = stationRepository.save(Station(name = "서울역", description = "테스트용"))
+            station2 = stationRepository.save(Station(name = "시청역", description = "테스트용"))
+
+            line1 = lineRepository.save(Line(name = "1호선", color = "#0052A4"))
+            line2 = lineRepository.save(Line(name = "2호선", color = "#00A84D"))
+            line3 = lineRepository.save(Line(name = "3호선", color = "#CE7C00"))
+
+            entityManager.flush()
+            entityManager.clear()
+        }
+
+        // ========== putStationLine 테스트 ==========
+
+        @Test
+        @DisplayName("유효한 요청으로 역에 노선 추가 시 정상적으로 연결된다")
+        fun putStationLine_WithValidRequest_ConnectsLinesToStation() {
+            // when
+            val result = onboardingLineService.putStationLine(station1.id!!, listOf(line1.id!!, line2.id!!))
+
+            // then
+            assertThat(result).isEqualTo(station1.id)
+            assertThat(stationLineRepository.findByStation(station1)).isNotNull
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 역 ID로 노선 추가 시 예외가 발생한다")
+        fun putStationLine_WithNonExistingStationId_ThrowsCustomException() {
+            // given
+            val nonExistingStationId = 9999L
+
+            // when & then
+            val exception =
+                assertThrows<CustomException> {
+                    onboardingLineService.putStationLine(nonExistingStationId, listOf(line1.id!!))
+                }
+            assertThat(exception.errorCode.name).isEqualTo("NOT_FOUND_STATION")
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 노선 ID가 포함된 경우 예외가 발생한다")
+        fun putStationLine_WithNonExistingLineId_ThrowsCustomException() {
+            val nonExistingLineId = 9999L
+            val exception =
+                assertThrows<CustomException> {
+                    onboardingLineService.putStationLine(station1.id!!, listOf(line1.id!!, nonExistingLineId))
+                }
+            assertThat(exception.errorCode.name).isEqualTo("NOT_FOUND_LINE")
+        }
+
+        @Test
+        @DisplayName("이미 연결된 노선을 다시 추가하려고 하면 예외가 발생한다")
+        fun putStationLine_WithAlreadyConnectedLine_ThrowsCustomException() {
+            // given
+            onboardingLineService.putStationLine(station1.id!!, listOf(line1.id!!))
+            entityManager.flush()
+            entityManager.clear()
+            // when & then
+            val exception =
+                assertThrows<CustomException> {
+                    onboardingLineService.putStationLine(station1.id!!, listOf(line1.id!!))
+                }
+
+            assertThat(exception.errorCode.name).isEqualTo("ALREADY_CONNECTED_LINE")
+        }
+
+        // ========== deleteStationLine 테스트 ==========
+
+        @Test
+        @DisplayName("유효한 요청으로 역에서 노선 삭제 시 정상적으로 제거된다")
+        fun deleteStationLine_WithValidRequest_RemovesConnection() {
+            // given
+            onboardingLineService.putStationLine(station1.id!!, listOf(line1.id!!))
+            entityManager.flush()
+            entityManager.clear()
+
+            // when
+            onboardingLineService.deleteStationLine(station1.id!!, line1.id!!)
+
+            // then
+            assertThat(stationLineRepository.findByStation(station1)).isEmpty()
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 역 ID로 노선 삭제 시 예외가 발생한다")
+        fun deleteStationLine_WithNonExistingStationId_ThrowsCustomException() {
+            val nonexistingLineId = 9999L
+
+            val exception =
+                assertThrows<CustomException> {
+                    onboardingLineService.deleteStationLine(station1.id!!, nonexistingLineId)
+                }
+            assertThat(exception.errorCode.name).isEqualTo("NOT_FOUND_LINE")
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 노선 ID로 삭제 시 예외가 발생한다")
+        fun deleteStationLine_WithNonExistingLineId_ThrowsCustomException() {
+            val nonExistingStationId = 9999L
+
+            val exception =
+                assertThrows<CustomException> {
+                    onboardingLineService.deleteStationLine(nonExistingStationId, line1.id!!)
+                }
+
+            assertThat(exception.errorCode.name).isEqualTo("NOT_FOUND_STATION")
+        }
+
+        @Test
+        @DisplayName("연결되지 않은 역-노선 관계를 삭제하려고 하면 예외가 발생한다")
+        fun deleteStationLine_WithNonExistingConnection_ThrowsCustomException() {
+            // when & then
+            val exception =
+                assertThrows<CustomException> {
+                    onboardingLineService.deleteStationLine(station1.id!!, line1.id!!)
+                }
+            assertThat(exception.errorCode.name).isEqualTo("NOT_FOUND_STATION_LINE")
+        }
+
+        // ========== findStationTwoLine 테스트 ==========
+
+        @Test
+        @DisplayName("환승역이 있을 때 2개 이상의 노선이 연결된 역 목록이 반환된다")
+        fun findStationTwoLine_WithTransferStations_ReturnsTransferStations() {
+            // given
+            onboardingLineService.putStationLine(station1.id!!, listOf(line1.id!!, line2.id!!))
+            onboardingLineService.putStationLine(station2.id!!, listOf(line1.id!!))
+            entityManager.flush()
+            entityManager.clear()
+
+            // when
+            val result = onboardingLineService.findStationTwoLine()
+
+            // then
+            assertThat(result).hasSize(1) // station1만 환승역
+            assertThat(result[0].name).isEqualTo("서울역")
+            assertThat(result[0].lines).hasSize(2)
+        }
+
+        @Test
+        @DisplayName("환승역이 없을 때 빈 리스트가 반환된다")
+        fun findStationTwoLine_WithoutTransferStations_ReturnsEmptyList() {
+            // given
+            // 모든 역에 노선을 1개씩만 연결 (환승역 없음)
+            onboardingLineService.putStationLine(station1.id!!, listOf(line1.id!!))
+            onboardingLineService.putStationLine(station2.id!!, listOf(line2.id!!))
+            entityManager.flush()
+            entityManager.clear()
+
+            // when
+            val result = onboardingLineService.findStationTwoLine()
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }

--- a/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep8ComplexDomainTest.kt
+++ b/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep8ComplexDomainTest.kt
@@ -58,7 +58,7 @@ class OnboardingStep8ComplexDomainTest
 
             // then
             assertThat(result).isEqualTo(station1.id)
-            assertThat(stationLineRepository.findByStation(station1)).isNotNull
+            assertThat(stationLineRepository.findByStation(station1)).hasSize(2)
         }
 
         @Test
@@ -122,18 +122,6 @@ class OnboardingStep8ComplexDomainTest
         @Test
         @DisplayName("존재하지 않는 역 ID로 노선 삭제 시 예외가 발생한다")
         fun deleteStationLine_WithNonExistingStationId_ThrowsCustomException() {
-            val nonexistingLineId = 9999L
-
-            val exception =
-                assertThrows<CustomException> {
-                    onboardingLineService.deleteStationLine(station1.id!!, nonexistingLineId)
-                }
-            assertThat(exception.errorCode.name).isEqualTo("NOT_FOUND_LINE")
-        }
-
-        @Test
-        @DisplayName("존재하지 않는 노선 ID로 삭제 시 예외가 발생한다")
-        fun deleteStationLine_WithNonExistingLineId_ThrowsCustomException() {
             val nonExistingStationId = 9999L
 
             val exception =
@@ -142,6 +130,18 @@ class OnboardingStep8ComplexDomainTest
                 }
 
             assertThat(exception.errorCode.name).isEqualTo("NOT_FOUND_STATION")
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 노선 ID로 삭제 시 예외가 발생한다")
+        fun deleteStationLine_WithNonExistingLineId_ThrowsCustomException() {
+            val nonexistingLineId = 9999L
+
+            val exception =
+                assertThrows<CustomException> {
+                    onboardingLineService.deleteStationLine(station1.id!!, nonexistingLineId)
+                }
+            assertThat(exception.errorCode.name).isEqualTo("NOT_FOUND_LINE")
         }
 
         @Test

--- a/core/src/test/kotlin/com/pluxity/onboarding/SoftDeleteJoinedInheritanceTest.kt
+++ b/core/src/test/kotlin/com/pluxity/onboarding/SoftDeleteJoinedInheritanceTest.kt
@@ -1,0 +1,98 @@
+package com.pluxity.onboarding
+
+import com.pluxity.station.Line
+import com.pluxity.station.LineRepository
+import com.pluxity.station.Station
+import com.pluxity.station.StationLine
+import com.pluxity.station.StationLineRepository
+import com.pluxity.station.StationRepository
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.dao.InvalidDataAccessResourceUsageException
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@Transactional
+@DisplayName("@SoftDelete와 @Inheritance(JOINED) 문제 재현 테스트")
+class SoftDeleteJoinedInheritanceTest
+    @Autowired
+    constructor(
+        private val stationRepository: StationRepository,
+        private val lineRepository: LineRepository,
+        private val stationLineRepository: StationLineRepository,
+        private val entityManager: EntityManager,
+    ) {
+        private lateinit var station: Station
+        private lateinit var line: Line
+        private lateinit var stationLine: StationLine
+
+        @BeforeEach
+        fun setUp() {
+            // Station 생성
+            station = stationRepository.save(Station(name = "테스트역", description = "테스트용 역"))
+            entityManager.flush()
+            entityManager.clear()
+
+            // Line 생성
+            line = lineRepository.save(Line(name = "1호선", color = "#0052A4"))
+            entityManager.flush()
+            entityManager.clear()
+
+            // StationLine 생성
+            stationLine =
+                stationLineRepository.save(
+                    StationLine(
+                        station = station,
+                        line = line,
+                    ),
+                )
+            entityManager.flush()
+            entityManager.clear()
+        }
+
+        @Test
+        @DisplayName("existsByStationId()는 부모 테이블 JOIN 누락으로 예외 발생")
+        fun existsByStationId_whenUsingId_thenMissingFromClauseError() {
+            // When & Then: ID로 조회 시 SQL 오류 발생
+            assertThrows<InvalidDataAccessResourceUsageException> {
+                stationLineRepository.existsByStationId(station.id!!)
+            }.also { exception ->
+                // ERROR: missing FROM-clause entry for table "s1_1"
+                assertThat(exception.message).contains("missing FROM-clause")
+            }
+        }
+
+        @Test
+        @DisplayName("existsByStation()는 엔티티 기반 조회로 정상 동작")
+        fun existsByStation_whenUsingEntity_thenWorksWithJoin() {
+            // When: 엔티티 객체로 조회
+            val station = stationRepository.findById(this.station.id!!).get()
+            val exists = stationLineRepository.existsByStation(station)
+
+            // Then: 정상 작동
+            assertThat(exists).isTrue()
+        }
+
+        @Test
+        @DisplayName("findByStationId()도 부모 테이블 JOIN 누락으로 예외 발생")
+        fun findByStationId_whenUsingId_thenMissingFromClauseError() {
+            assertThrows<InvalidDataAccessResourceUsageException> {
+                stationLineRepository.findByStationId(station.id!!)
+            }.also { exception ->
+                assertThat(exception.message).contains("missing FROM-clause")
+            }
+        }
+
+        @Test
+        @DisplayName("findByStationIdWithQuery()는 JPQL 명시적 JOIN으로 정상 동작")
+        fun findByStationIdWithQuery_whenUsingExplicitJoin_thenSuccess() {
+            val result = stationLineRepository.findByStationIdWithQuery(station.id!!)
+            assertThat(result).isNotNull
+        }
+    }


### PR DESCRIPTION
## 요약
복합 도메인 및 트랜잭션 학습 및  @SoftDelete + JOINED 상속 구조 쿼리 메서드 버그 테스트

## 이슈 넘버 or 관련 링크
https://github.com/pluxity/docs/blob/main/onboarding/api/08_COMPLEX_DOMAIN.md

## 변경사항 🏗️  

- 과제 1: 지하철 노선 관리 기능 구현
- 과제 2: 환승역 조회 쿼리 작성

## SoftDelete + JOINED 상속 구조 쿼리 메서드 버그 리포트

관련 이슈:` https://github.com/spring-projects/spring-data-jpa/issues/3304`

`Facility(@SoftDelete, JOINED 상속)` – `Station` – `StationLine` 연관관계에서, **Station을 ID로 필터링하는 메서드들이 부모 테이블(Facility)에 JOIN되지 않아 SQL 오류가 발생하는 문제**

#### 문제 요약

- 구조
  - `Facility` : `@Inheritance(JOINED) + @SoftDelete(deleted)`
  - `Station` : `Facility` 상속
  - `StationLine` : `@ManyToOne station: Station`
- 아래와 같이 **ID 기반 메서드**를 사용하면:
  - `fun existsByStationId(stationId: Long): Boolean`
  - `fun findByStationId(stationId: Long): List<StationLine>`
- Hibernate가 `station_line` ↔ `station`까지만 JOIN하고, `facility.deleted` 조건만 추가하여
  - `ERROR: missing FROM-clause entry for table "s1_1"` (부모 테이블 누락) 예외 발생

#### 검증한 쿼리 패턴

- 실패
  - `existsByStationId(station.id!!)`
  - `findByStationId(station.id!!)`
  - 공통적으로 Facility JOIN 없이 `… AND s1_1.deleted = false` 형태의 SQL 생성 → FROM 절에 `s1_1`이 없어 실패
- 성공
  - `existsByStation(station: Station)`
    - `station` → `facility`까지 JOIN이 포함된 SQL 생성
  - 명시적 JPQL
    ```
    @Query("""
        select sl
        from StationLine sl
        join fetch sl.station s
        where s.id = :stationId
    """)
    fun findByStationIdWithQuery(stationId: Long): List<StationLine>
    ```
    - `station` + `facility`를 모두 JOIN하는 쿼리로 변환되어 정상 동작

#### 결론

- `StationLine` 조회 시 **Station의 ID로 직접 필터링하는 메서드는 지양**하고,
  - 엔티티 기반(`existsByStation(Station)`) 메서드 또는
  - Facility까지 JOIN을 명시한 JPQL/Native 쿼리로 대체





