### PR TITLE
Onboarding/step 9 scenario

### DIFF
--- a/collect/src/main/kotlin/com/pluxity/onboarding/OnboardingCollector.kt
+++ b/collect/src/main/kotlin/com/pluxity/onboarding/OnboardingCollector.kt
@@ -1,10 +1,7 @@
 package com.pluxity.onboarding
 
+import com.pluxity.climate.ClimateData
 import com.pluxity.config.WebClientFactory
-import com.pluxity.device.entity.Device
-import com.pluxity.device.repository.DeviceRepository
-import jakarta.transaction.Transactional
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
@@ -25,14 +22,11 @@ import org.springframework.web.reactive.function.client.awaitBody
 @Component
 class OnboardingCollector(
     clientFactory: WebClientFactory,
-    private val deviceRepository: DeviceRepository,
 ) {
     private val client = clientFactory.createClient("https://7f32047a-4f04-4221-bcd3-34e6a3534d85.mock.pstmn.io")
 
-    @Transactional
-    suspend fun collectData(): List<MockData> {
+    suspend fun collectData(): List<ClimateData> {
         val mockData = getMockData()
-        saveMockData(mockData)
         return mockData
     }
 
@@ -46,19 +40,19 @@ class OnboardingCollector(
      * @return 수집된 MockData 리스트 (최대 5개)
      *
      */
-    suspend fun getMockData(fetcher: suspend (Int) -> MockData = { id -> fetchData(id) }): List<MockData> =
+    suspend fun getMockData(fetcher: suspend (Int) -> ClimateData = { id -> fetchData(id) }): List<ClimateData> =
         supervisorScope {
             (1..5)
                 .map { i ->
                     println("[$i] 시작 - ${Thread.currentThread().name}")
-                    async(Dispatchers.IO) { fetchWithRetry(id = i, fetcher = fetcher) } // 여기서 await() 하면 요청하고 바로 응답을 기다리기 떄문에 직렬처리됨
+                    async { fetchWithRetry(id = i, fetcher = fetcher) } // 여기서 await() 하면 요청하고 바로 응답을 기다리기 떄문에 직렬처리됨
                 }.awaitAll()
         }
 
     /**
      *   WebClient를 사용하여 비동기로 HTTP GET 요청을 수행
      */
-    suspend fun fetchData(id: Int): MockData =
+    suspend fun fetchData(id: Int): ClimateData =
         client
             .get()
             .uri("?deviceId=$id")
@@ -72,8 +66,8 @@ class OnboardingCollector(
         id: Int,
         maxRetry: Int = 3,
         attempt: Int = 0,
-        fetcher: suspend (Int) -> MockData,
-    ): MockData =
+        fetcher: suspend (Int) -> ClimateData,
+    ): ClimateData =
         try {
             println("[$id] 시도 ${attempt + 1}/${maxRetry + 1}")
             fetcher(id)
@@ -88,18 +82,4 @@ class OnboardingCollector(
                 throw e
             }
         }
-
-    private fun saveMockData(dataList: List<MockData>) {
-        val deviceList =
-            dataList.map { data ->
-                Device(
-                    id = data.id,
-                    name = data.name,
-                    deviceType = data.deviceType,
-                    companyType = data.companyType,
-                )
-            }
-
-        deviceRepository.saveAll(deviceList)
-    }
 }

--- a/common/src/main/kotlin/com/pluxity/device/repository/DeviceRepository.kt
+++ b/common/src/main/kotlin/com/pluxity/device/repository/DeviceRepository.kt
@@ -37,5 +37,5 @@ interface DeviceRepository :
 
     @EntityGraph(attributePaths = ["feature", "feature.facility"])
     @Query("SELECT d FROM Device d WHERE d.id in :ids")
-    fun findByIdInWithFeatureAndFacility(ids: List<String>): List<Device>?
+    fun findByIdInWithFeatureAndFacility(ids: List<String>): List<Device>
 }

--- a/common/src/main/kotlin/com/pluxity/device/repository/DeviceRepository.kt
+++ b/common/src/main/kotlin/com/pluxity/device/repository/DeviceRepository.kt
@@ -34,4 +34,8 @@ interface DeviceRepository :
     @EntityGraph(attributePaths = ["category"])
     @Query("SELECT d FROM Device d WHERE d.id = :id")
     fun findByIdWithCategory(id: String): Device?
+
+    @EntityGraph(attributePaths = ["feature", "feature.facility"])
+    @Query("SELECT d FROM Device d WHERE d.id in :ids")
+    fun findByIdInWithFeatureAndFacility(ids: List<String>): List<Device>?
 }

--- a/common/src/main/kotlin/com/pluxity/global/config/OnboardingAsyncConfig.kt
+++ b/common/src/main/kotlin/com/pluxity/global/config/OnboardingAsyncConfig.kt
@@ -1,0 +1,22 @@
+package com.pluxity.global.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@EnableAsync
+@Configuration
+class OnboardingAsyncConfig {
+    @Bean
+    fun taskExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 5
+        executor.maxPoolSize = 10
+        executor.queueCapacity = 25
+        executor.setThreadNamePrefix("onboarding-task-")
+        executor.initialize()
+        return executor
+    }
+}

--- a/common/src/main/kotlin/com/pluxity/onboarding/Alert.kt
+++ b/common/src/main/kotlin/com/pluxity/onboarding/Alert.kt
@@ -1,0 +1,47 @@
+package com.pluxity.onboarding
+
+import com.pluxity.device.entity.Device
+import com.pluxity.facility.Facility
+import com.pluxity.global.entity.BaseEntity
+import com.pluxity.user.entity.User
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+
+/**
+ * 온보딩용 알람 저장 테이블
+ *
+ * OnboardingCollector에서 수집한 데이터중 미세먼지 농도가 나쁨 상태인 데이터를 해당 station을 관리하는 담당자에게 알림을 발생
+ */
+
+@Entity
+class Alert(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    var user: User? = null,
+    @ManyToOne
+    @JoinColumn(name = "device_id")
+    var device: Device? = null,
+    @ManyToOne
+    @JoinColumn(name = "station_id")
+    var facility: Facility? = null,
+    val message: String? = null,
+) : BaseEntity() {
+    fun changeUser(user: User?) {
+        this.user = user
+    }
+
+    fun changeDevice(device: Device?) {
+        this.device = device
+    }
+
+    fun changeStation(facility: Facility) {
+        this.facility = facility
+    }
+}

--- a/common/src/main/kotlin/com/pluxity/onboarding/AlertEvent.kt
+++ b/common/src/main/kotlin/com/pluxity/onboarding/AlertEvent.kt
@@ -1,0 +1,5 @@
+package com.pluxity.onboarding
+
+data class AlertEvent(
+    val targetDeviceIds: List<String>,
+)

--- a/common/src/main/kotlin/com/pluxity/onboarding/AlertRepository.kt
+++ b/common/src/main/kotlin/com/pluxity/onboarding/AlertRepository.kt
@@ -1,0 +1,5 @@
+package com.pluxity.onboarding
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AlertRepository : JpaRepository<Alert, Long>

--- a/common/src/main/kotlin/com/pluxity/onboarding/OnboardingAlertEventListener.kt
+++ b/common/src/main/kotlin/com/pluxity/onboarding/OnboardingAlertEventListener.kt
@@ -1,0 +1,38 @@
+package com.pluxity.onboarding
+
+import com.pluxity.device.repository.DeviceRepository
+import com.pluxity.permission.ResourceType
+import com.pluxity.user.repository.UserRepository
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class OnboardingAlertEventListener(
+    private val alertRepository: AlertRepository,
+    private val deviceRepository: DeviceRepository,
+    private val userRepository: UserRepository,
+) {
+    @Async
+    @EventListener
+    @Transactional
+    fun handleAlert(event: AlertEvent) {
+        val devices = deviceRepository.findByIdInWithFeatureAndFacility(event.targetDeviceIds) ?: return
+
+        devices.forEach { device ->
+            val facility = device.feature?.facility ?: return
+            val users = userRepository.findByPermission(ResourceType.FACILITY.name, facility.id!!)
+
+            users.forEach { user ->
+                alertRepository.save(
+                    Alert(
+                        user = user,
+                        facility = facility,
+                        device = device,
+                    ),
+                )
+            }
+        }
+    }
+}

--- a/common/src/main/kotlin/com/pluxity/onboarding/OnboardingAlertEventListener.kt
+++ b/common/src/main/kotlin/com/pluxity/onboarding/OnboardingAlertEventListener.kt
@@ -18,21 +18,21 @@ class OnboardingAlertEventListener(
     @EventListener
     @Transactional
     fun handleAlert(event: AlertEvent) {
-        val devices = deviceRepository.findByIdInWithFeatureAndFacility(event.targetDeviceIds) ?: return
+        val devices = deviceRepository.findByIdInWithFeatureAndFacility(event.targetDeviceIds)
 
         devices.forEach { device ->
-            val facility = device.feature?.facility ?: return
+            val facility = device.feature?.facility ?: return@forEach
             val users = userRepository.findByPermission(ResourceType.FACILITY.name, facility.id!!)
 
-            users.forEach { user ->
-                alertRepository.save(
+            val alerts =
+                users.map { user ->
                     Alert(
                         user = user,
                         facility = facility,
                         device = device,
-                    ),
-                )
-            }
+                    )
+                }
+            alertRepository.saveAll(alerts)
         }
     }
 }

--- a/common/src/main/kotlin/com/pluxity/user/repository/UserRepository.kt
+++ b/common/src/main/kotlin/com/pluxity/user/repository/UserRepository.kt
@@ -1,9 +1,11 @@
 package com.pluxity.user.repository
 
 import com.pluxity.user.entity.User
+import io.lettuce.core.dynamic.annotation.Param
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 
 interface UserRepository : JpaRepository<User, Long> {
     @EntityGraph(
@@ -26,4 +28,21 @@ interface UserRepository : JpaRepository<User, Long> {
         ],
     )
     fun findByUsername(username: String): User?
+
+    @Query(
+        """
+    SELECT DISTINCT u FROM User u
+    JOIN u.userRoles ur
+    JOIN ur.role r
+    JOIN r.rolePermissions rp
+    JOIN rp.permissionGroup pg
+    JOIN pg.permissions p
+    WHERE p.resourceName = :resourceName
+      AND p.resourceId = :resourceId
+""",
+    )
+    fun findByPermission(
+        @Param("resourceName") resourceName: String,
+        @Param("resourceId") resourceId: Long,
+    ): List<User>
 }

--- a/common/src/main/kotlin/com/pluxity/user/repository/UserRepository.kt
+++ b/common/src/main/kotlin/com/pluxity/user/repository/UserRepository.kt
@@ -1,11 +1,11 @@
 package com.pluxity.user.repository
 
 import com.pluxity.user.entity.User
-import io.lettuce.core.dynamic.annotation.Param
 import org.springframework.data.domain.Sort
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface UserRepository : JpaRepository<User, Long> {
     @EntityGraph(

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingController.kt
@@ -1,5 +1,6 @@
 package com.pluxity.onboarding
 
+import com.pluxity.climate.ClimateData
 import com.pluxity.global.annotation.ResponseCreated
 import com.pluxity.global.response.ErrorResponseBody
 import com.pluxity.onboarding.dto.AdminUserCreateRequest
@@ -247,7 +248,7 @@ class OnboardingController(
         ],
     )
     @GetMapping("/collect")
-    suspend fun collectData(): ResponseEntity<List<MockData>> = ResponseEntity.ok(collector.collectData())
+    suspend fun collectData(): ResponseEntity<List<ClimateData>> = ResponseEntity.ok(collector.collectData())
 
     @Operation(
         summary = "역에 노선 추가",

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingJob.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingJob.kt
@@ -1,0 +1,33 @@
+package com.pluxity.onboarding
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class OnboardingJob(
+    private val collector: OnboardingCollector,
+    private val persister: OnboardingPersister,
+) {
+    val scope =
+        CoroutineScope(
+            Dispatchers.IO +
+                CoroutineName("onboarding-job") +
+                CoroutineExceptionHandler { _, throwable ->
+                    log.error { "onboarding-job error: ${throwable.message}" }
+                },
+        )
+
+    fun trigger() {
+        scope.launch {
+            val data = collector.collectData()
+            persister.persistAndAlert(data)
+        }
+    }
+}

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingPersister.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingPersister.kt
@@ -24,7 +24,7 @@ class OnboardingPersister(
     private fun sendAlert(dataList: List<ClimateData>) {
         val targetDeviceIds =
             dataList
-                .filter { it.temperature!! >= 80 }
+                .filter { it.temperature != null && it.temperature!! >= 80 }
                 .mapNotNull { it.deviceId }
                 .distinct()
 

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingPersister.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingPersister.kt
@@ -1,0 +1,35 @@
+package com.pluxity.onboarding
+
+import com.pluxity.climate.ClimateData
+import com.pluxity.climate.ClimateDataRepository
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class OnboardingPersister(
+    private val climateDataRepository: ClimateDataRepository,
+    private val eventPublisher: ApplicationEventPublisher,
+) {
+    @Transactional
+    fun persistAndAlert(dataList: List<ClimateData>) {
+        saveClimateData(dataList)
+        sendAlert(dataList)
+    }
+
+    private fun saveClimateData(dataList: List<ClimateData>) {
+        climateDataRepository.saveAll(dataList)
+    }
+
+    private fun sendAlert(dataList: List<ClimateData>) {
+        val targetDeviceIds =
+            dataList
+                .filter { it.temperature!! >= 80 }
+                .mapNotNull { it.deviceId }
+                .distinct()
+
+        if (targetDeviceIds.isNotEmpty()) {
+            eventPublisher.publishEvent(AlertEvent(targetDeviceIds))
+        }
+    }
+}

--- a/core/src/main/kotlin/com/pluxity/onboarding/OnboardingSchedule.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/OnboardingSchedule.kt
@@ -1,0 +1,16 @@
+package com.pluxity.onboarding
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(name = ["onboarding.schedule"], havingValue = "true")
+class OnboardingSchedule(
+    private val job: OnboardingJob,
+) {
+    @Scheduled(cron = "0 0/1 * * * *")
+    fun schedule() {
+        job.trigger()
+    }
+}

--- a/core/src/main/kotlin/com/pluxity/onboarding/service/OnboardingBuildingService.kt
+++ b/core/src/main/kotlin/com/pluxity/onboarding/service/OnboardingBuildingService.kt
@@ -1,7 +1,7 @@
 package com.pluxity.onboarding.service
 
-import com.pluxity.building.Building
 import com.pluxity.onboarding.dto.OnboardingFacilityRequest
+import com.pluxity.station.Station
 import org.springframework.stereotype.Service
 
 @Service
@@ -10,7 +10,7 @@ class OnboardingBuildingService(
 ) {
     fun save(request: OnboardingFacilityRequest): Long {
         val building =
-            Building(
+            Station(
                 name = request.name,
                 description = request.description,
             )

--- a/core/src/main/resources/application-local.yml
+++ b/core/src/main/resources/application-local.yml
@@ -28,8 +28,8 @@ file:
   local:
     path: C:/Dev/Upload/
   s3:
-#    endpoint-url: http://127.0.0.1:9000
-    endpoint-url: ${S3_ENDPOINT_URL:http://192.168.10.181:8204}
+    endpoint-url: http://127.0.0.1:9000
+#    endpoint-url: ${S3_ENDPOINT_URL:http://192.168.10.181:8204}
     public-url: ${S3_PUBLIC_URL:http://192.168.10.181:8204}
     bucket: plug-platform
     region: ap-northeast-2
@@ -40,3 +40,6 @@ file:
 logging:
   level:
     com: DEBUG
+
+onboarding:
+  schedule: true

--- a/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep6BusinessLogicTest.kt
+++ b/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep6BusinessLogicTest.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 
 /**
@@ -33,7 +34,8 @@ import org.springframework.transaction.annotation.Transactional
  */
 @SpringBootTest
 @Transactional
-class OnboardingStep6BusinessLogic
+@ActiveProfiles("test")
+class OnboardingStep6BusinessLogicTest
     @Autowired
     constructor(
         private val deviceControlledService: OnboardingDeviceService,

--- a/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep7DataCollectionTest.kt
+++ b/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep7DataCollectionTest.kt
@@ -1,7 +1,6 @@
 package com.pluxity.onboarding
 
-import com.pluxity.device.entity.DeviceCompanyType
-import com.pluxity.device.entity.DeviceType
+import com.pluxity.climate.ClimateData
 import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -13,7 +12,6 @@ class OnboardingStep7DataCollectionTest {
     private val service =
         OnboardingCollector(
             clientFactory = mockk(relaxed = true),
-            deviceRepository = mockk(relaxed = true),
         )
 
     @Test
@@ -24,16 +22,14 @@ class OnboardingStep7DataCollectionTest {
             val callTimestamps = mutableListOf<Pair<Int, Long>>()
 
             // 코루틴의 각 호출의 시작 시간을 기록하여 병렬성 검증
-            val mockFetcher: suspend (Int) -> MockData = { id ->
+            val mockFetcher: suspend (Int) -> ClimateData = { id ->
                 val startTime = System.currentTimeMillis() // 시작 시간
                 callTimestamps.add(id to startTime)
                 println("[$id] 호출 시작: $startTime")
                 delay(1000)
-                MockData(
-                    id = "test-device-id",
-                    name = "test-device-name",
-                    deviceType = DeviceType.TEMP_HUM,
-                    companyType = DeviceCompanyType.DAWONDNS,
+                ClimateData(
+                    deviceId = "test-device-id",
+                    temperature = 20.0,
                 )
             }
 
@@ -59,7 +55,7 @@ class OnboardingStep7DataCollectionTest {
         runBlocking {
             // given
             var callCount = 0
-            val mockFetcher: suspend (Int) -> MockData = { id ->
+            val mockFetcher: suspend (Int) -> ClimateData = { id ->
                 callCount++
                 println("Mock 호출 횟수: $callCount")
 
@@ -67,11 +63,9 @@ class OnboardingStep7DataCollectionTest {
                     1 -> throw RuntimeException("1번 실패")
                     2 -> throw RuntimeException("2번 실패")
                     else ->
-                        MockData(
-                            id = "test-device-id",
-                            name = "test-device-name",
-                            deviceType = DeviceType.TEMP_HUM,
-                            companyType = DeviceCompanyType.DAWONDNS,
+                        ClimateData(
+                            deviceId = "test-device-id",
+                            temperature = 20.0,
                         )
                 }
             }
@@ -80,6 +74,6 @@ class OnboardingStep7DataCollectionTest {
             val result = service.fetchWithRetry(1, fetcher = mockFetcher)
 
             assertEquals(3, callCount)
-            assertEquals("test-device-id", result.id)
+            assertEquals("test-device-id", result.deviceId)
         }
 }

--- a/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep8ComplexDomainTest.kt
+++ b/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep8ComplexDomainTest.kt
@@ -15,10 +15,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 class OnboardingStep8ComplexDomainTest
     @Autowired
     constructor(

--- a/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep9Scenario.kt
+++ b/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep9Scenario.kt
@@ -1,0 +1,186 @@
+package com.pluxity.onboarding
+
+import com.pluxity.climate.ClimateData
+import com.pluxity.climate.ClimateDataRepository
+import com.pluxity.device.entity.Device
+import com.pluxity.device.entity.DeviceCompanyType
+import com.pluxity.device.entity.DeviceType
+import com.pluxity.device.repository.DeviceRepository
+import com.pluxity.facility.Facility
+import com.pluxity.facility.FacilityRepository
+import com.pluxity.feature.entity.Feature
+import com.pluxity.feature.repository.FeatureRepository
+import com.pluxity.permission.Permission
+import com.pluxity.permission.PermissionGroup
+import com.pluxity.permission.PermissionGroupRepository
+import com.pluxity.permission.PermissionRepository
+import com.pluxity.permission.ResourceType
+import com.pluxity.station.Station
+import com.pluxity.user.entity.Role
+import com.pluxity.user.entity.RolePermission
+import com.pluxity.user.entity.User
+import com.pluxity.user.repository.RolePermissionRepository
+import com.pluxity.user.repository.RoleRepository
+import com.pluxity.user.repository.UserRepository
+import com.pluxity.user.repository.UserRoleRepository
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest
+class OnboardingStep9Scenario
+    @Autowired
+    constructor(
+        private val job: OnboardingJob,
+        private val climateDataRepository: ClimateDataRepository,
+        private val alertRepository: AlertRepository,
+        private val roleRepository: RoleRepository,
+        private val permissionGroupRepository: PermissionGroupRepository,
+        private val permissionRepository: PermissionRepository,
+        private val rolePermissionRepository: RolePermissionRepository,
+        private val userRoleRepository: UserRoleRepository,
+        private val deviceRepository: DeviceRepository,
+        private val facilityRepository: FacilityRepository,
+        private val userRepository: UserRepository,
+        private val featureRepository: FeatureRepository,
+    ) {
+        @MockitoBean lateinit var collector: OnboardingCollector
+
+        lateinit var facility: Facility
+        lateinit var device: Device
+        lateinit var user: User
+
+        @BeforeEach
+        fun setUp() {
+            climateDataRepository.deleteAll()
+            alertRepository.deleteAll()
+            userRoleRepository.deleteAll()
+            rolePermissionRepository.deleteAll()
+            roleRepository.deleteAll()
+            userRepository.deleteAll()
+            permissionRepository.deleteAll()
+            permissionGroupRepository.deleteAll()
+            deviceRepository.deleteAll()
+            featureRepository.deleteAll()
+            facilityRepository.deleteAll()
+
+            facility = facilityRepository.save(Station("test-station"))
+
+            val permission =
+                permissionRepository.save(
+                    Permission(
+                        resourceName = ResourceType.FACILITY.name, // "FACILITY"
+                        resourceId = facility.id.toString(),
+                    ),
+                )
+
+            val permissionGroup =
+                permissionGroupRepository.save(
+                    PermissionGroup(
+                        name = "Station Access Group",
+                        description = "Can access specific station",
+                    ),
+                )
+            permissionGroup.addPermission(permission)
+            permissionRepository.save(permission)
+
+            val role =
+                roleRepository.save(
+                    Role(
+                        name = "STATION_MANAGER",
+                        description = "Manages Stations",
+                    ),
+                )
+
+            val rolePermission =
+                rolePermissionRepository.save(
+                    RolePermission(
+                        role = role,
+                        permissionGroup = permissionGroup,
+                    ),
+                )
+
+            role.addRolePermission(rolePermission)
+
+            user =
+                userRepository.save(
+                    User(
+                        username = "manager",
+                        password = "password",
+                        name = "Manager Kim",
+                        code = "M001",
+                        department = "Facility Dept",
+                    ),
+                )
+
+            user.addRole(role)
+            userRepository.save(user)
+
+            val feature = featureRepository.save(Feature(id = "feature-1", facility = facility))
+            device =
+                deviceRepository.save(
+                    Device(
+                        id = "DEV-001",
+                        name = "Sensor 1",
+                        feature = feature,
+                        deviceType = DeviceType.TEMP_HUM,
+                        companyType = DeviceCompanyType.DAWONDNS,
+                    ),
+                )
+        }
+
+        // Case 1: 정상 알림
+        @Test
+        @DisplayName("온도 80도 이상이면 데이터 저장 및 알림이 생성된다")
+        fun shouldSaveDataAndCreateAlert_WhenTemperatureIsOver80() {
+            // given
+            val badData = ClimateData(deviceId = device.id, temperature = 85.0)
+
+            runBlocking {
+                given(collector.collectData()).willReturn(listOf(badData))
+            }
+
+            // when
+            job.trigger()
+
+            // then
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+                val savedData = climateDataRepository.findAll()
+                assertThat(savedData).hasSize(1)
+                assertThat(savedData[0].temperature).isEqualTo(85.0)
+
+                val alerts = alertRepository.findAll()
+                assertThat(alerts).hasSize(1)
+                assertThat(alerts[0].device?.id).isEqualTo(device.id)
+                assertThat(alerts[0].user?.id).isEqualTo(user.id)
+            }
+        }
+
+        @DisplayName("온도 80도 미만이면 데이터만 저장되고 알림은 생성되지 않는다")
+        @Test
+        fun shouldOnlySaveData_WhenTemperatureIsUnder80() {
+            // given
+            val normalData = ClimateData(deviceId = device.id, temperature = 79.9)
+
+            runBlocking {
+                given(collector.collectData()).willReturn(listOf(normalData))
+            }
+
+            // when
+            job.trigger()
+
+            // then
+            await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+                assertThat(climateDataRepository.findAll()).hasSize(1)
+                assertThat(alertRepository.findAll()).isEmpty()
+            }
+        }
+    }

--- a/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep9ScenarioTest.kt
+++ b/core/src/test/kotlin/com/pluxity/onboarding/OnboardingStep9ScenarioTest.kt
@@ -32,11 +32,13 @@ import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import java.util.concurrent.TimeUnit
 
 @SpringBootTest
-class OnboardingStep9Scenario
+@ActiveProfiles("test")
+class OnboardingStep9ScenarioTest
     @Autowired
     constructor(
         private val job: OnboardingJob,


### PR DESCRIPTION
## 요약
종합 실전 시나이로 구현
지하철 역(Station)의 공기질 데이터를 주기적으로 수집하고, 특정 기준(온도/미세먼지 등) 초과 시 관리자에게 비동기로 알림을 발송하는 시스템 구축
 

## 이슈 넘버 or 관련 링크
  https://github.com/pluxity/docs/blob/main/onboarding/api/09_ADVANCED_SCENARIO.md

## 변경사항 🏗️  
1. 데이터 수집 및 스케줄링
    - `@Scheduled`를 사용하여 1분 주기로 OnboardingJob을 실행하도록 설정
2. 이벤트 기반 알림 시스템 
    - OnboardingAlertEventListener를 통해 알림 로직을 별도 스레드에서 비동기로 처리
3. 도메인 및 설정
    - Alert 엔티티: 알림 이력을 저장하기 위한 Alert 엔티티 및 리포지토리를 추가
    - 비동기 설정: OnboardingAsyncConfig를 통해 ThreadPool을 구성
4. 테스트 
     -통합 테스트 작성

