### PR TITLE
테스트 케이스 추가

### DIFF
--- a/common/src/main/kotlin/com/pluxity/asset/service/AssetCategoryService.kt
+++ b/common/src/main/kotlin/com/pluxity/asset/service/AssetCategoryService.kt
@@ -60,13 +60,13 @@ class AssetCategoryService(
                 assignToParent(parent)
             }
 
-        assetCategoryRepository.save(category)
+        val savedCategory = assetCategoryRepository.save(category)
 
         request.thumbnailFileId?.let {
-            fileService.finalizeUpload(it, "${ASSET_CATEGORIES}${category.id}")
+            fileService.finalizeUpload(it, "${ASSET_CATEGORIES}${savedCategory.requiredId}")
         }
 
-        return category.requiredId
+        return savedCategory.requiredId
     }
 
     @Transactional

--- a/common/src/main/kotlin/com/pluxity/permission/ResourceType.kt
+++ b/common/src/main/kotlin/com/pluxity/permission/ResourceType.kt
@@ -16,6 +16,6 @@ enum class ResourceType(
     companion object {
         fun fromString(resourceName: String): ResourceType =
             entries.firstOrNull { it != NONE && it.name.equals(resourceName, ignoreCase = true) }
-                ?: throw CustomException(ErrorCode.INVALID_RESOURCE_TYPE, "Resource type: $resourceName")
+                ?: throw CustomException(ErrorCode.INVALID_RESOURCE_TYPE, resourceName)
     }
 }

--- a/common/src/test/kotlin/com/pluxity/asset/AssetCategoryServiceKoTest.kt
+++ b/common/src/test/kotlin/com/pluxity/asset/AssetCategoryServiceKoTest.kt
@@ -1,0 +1,415 @@
+package com.pluxity.asset
+
+import asset.dummyAssetCategory
+import com.pluxity.asset.dto.AssetCategoryCreateRequest
+import com.pluxity.asset.dto.AssetCategoryUpdateRequest
+import com.pluxity.asset.repository.AssetCategoryRepository
+import com.pluxity.asset.service.AssetCategoryService
+import com.pluxity.category.dto.CategoryDepthResponse
+import com.pluxity.file.dto.FileResponse
+import com.pluxity.file.entity.FileEntity
+import com.pluxity.file.service.FileService
+import com.pluxity.global.constant.ErrorCode
+import com.pluxity.global.exception.CustomException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.springframework.data.domain.Sort
+import org.springframework.data.repository.findByIdOrNull
+
+class AssetCategoryServiceKoTest :
+    BehaviorSpec({
+
+        isolationMode = IsolationMode.InstancePerLeaf
+
+        val assetCategoryRepository = mockk<AssetCategoryRepository>()
+        val fileService = mockk<FileService>(relaxed = true)
+
+        val service =
+            AssetCategoryService(
+                assetCategoryRepository,
+                fileService,
+                assetCategoryRepository,
+            )
+
+        Given("모든 에셋 카테고리 조회 요청을 할 때") {
+            When("카테고리가 비어있다면") {
+                every { assetCategoryRepository.findAll(any<Sort>()) } returns emptyList()
+
+                val result = service.getAllCategories()
+
+                Then("빈 리스트를 반환한다.") {
+                    result shouldBe emptyList()
+                    verify(exactly = 1) { assetCategoryRepository.findAll(any<Sort>()) }
+                }
+            }
+
+            When("루트 카테고리만 존재한다면") {
+                val rootCategory1 = dummyAssetCategory(id = 1L, categoryName = "카테고리1", iconFileId = 10L)
+                val rootCategory2 = dummyAssetCategory(id = 2L, categoryName = "카테고리2", iconFileId = 20L)
+                val categories = listOf(rootCategory1, rootCategory2)
+
+                every { assetCategoryRepository.findAll(any<Sort>()) } returns categories
+                every { fileService.getFiles(any()) } returns
+                    listOf(
+                        FileResponse(id = 10L, originalFileName = "icon1.png"),
+                        FileResponse(id = 20L, originalFileName = "icon2.png"),
+                    )
+
+                val result = service.getAllCategories()
+
+                Then("루트 카테고리만 반환하고 파일 정보가 매핑된다.") {
+                    result.size shouldBe 2
+                    verify(exactly = 1) { assetCategoryRepository.findAll(any<Sort>()) }
+                    verify(exactly = 1) { fileService.getFiles(any()) }
+                }
+            }
+
+            When("루트와 자식 카테고리가 모두 존재한다면") {
+                val parentCategory = dummyAssetCategory(id = 1L, categoryName = "부모", iconFileId = 10L)
+                val childCategory = dummyAssetCategory(id = 2L, categoryName = "자식", iconFileId = 20L)
+                childCategory.parent = parentCategory
+                val categories = listOf(parentCategory, childCategory)
+
+                every { assetCategoryRepository.findAll(any<Sort>()) } returns categories
+                every { fileService.getFiles(any()) } returns
+                    listOf(
+                        FileResponse(id = 10L, originalFileName = "parent.png"),
+                        FileResponse(id = 20L, originalFileName = "child.png"),
+                    )
+
+                val result = service.getAllCategories()
+
+                Then("루트 카테고리만 반환한다.") {
+                    result.size shouldBe 1
+                    verify(exactly = 1) { assetCategoryRepository.findAll(any<Sort>()) }
+                }
+            }
+        }
+
+        Given("특정 부모의 자식 카테고리 조회 요청을 할 때") {
+            When("부모 ID가 유효하고 자식 카테고리가 있다면") {
+                val parentId = 1L
+                val child1 = dummyAssetCategory(id = 2L, categoryName = "자식1", iconFileId = 10L)
+                val child2 = dummyAssetCategory(id = 3L, categoryName = "자식2", iconFileId = 20L)
+
+                every { assetCategoryRepository.findByParentId(parentId) } returns listOf(child1, child2)
+                every { fileService.getFileResponse(10L) } returns FileResponse(id = 10L, originalFileName = "child1.png")
+                every { fileService.getFileResponse(20L) } returns FileResponse(id = 20L, originalFileName = "child2.png")
+
+                val result = service.getChildCategories(parentId)
+
+                Then("자식 카테고리 리스트를 반환하고 파일 정보가 매핑된다.") {
+                    result.size shouldBe 2
+                    verify(exactly = 1) { assetCategoryRepository.findByParentId(parentId) }
+                }
+            }
+
+            When("부모 ID가 유효하지만 자식 카테고리가 없다면") {
+                val parentId = 1L
+
+                every { assetCategoryRepository.findByParentId(parentId) } returns emptyList()
+
+                val result = service.getChildCategories(parentId)
+
+                Then("빈 리스트를 반환한다.") {
+                    result shouldBe emptyList()
+                    verify(exactly = 1) { assetCategoryRepository.findByParentId(parentId) }
+                }
+            }
+        }
+
+        Given("에셋 카테고리 생성 요청을 할 때") {
+            When("코드가 중복이라면") {
+                val request = AssetCategoryCreateRequest("카테고리", "DUPLICATE_CODE", null, null)
+
+                every { assetCategoryRepository.existsByCode(request.code) } returns true
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.createAssetCategory(request)
+                    }
+
+                Then("DUPLICATE_ASSET_CATEGORY_CODE 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.DUPLICATE_ASSET_CATEGORY_CODE.getMessage().format(request.code)
+                    verify(exactly = 1) { assetCategoryRepository.existsByCode(request.code) }
+                    verify(exactly = 0) { assetCategoryRepository.save(any()) }
+                }
+            }
+
+            When("부모 카테고리 ID가 유효하지 않다면") {
+                val invalidParentId = 999L
+                val request = AssetCategoryCreateRequest("카테고리", "CODE", invalidParentId, null)
+
+                every { assetCategoryRepository.existsByCode(request.code) } returns false
+                every { assetCategoryRepository.findByIdOrNull(invalidParentId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.createAssetCategory(request)
+                    }
+
+                Then("NOT_FOUND_CATEGORY 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.NOT_FOUND_CATEGORY.getMessage().format(invalidParentId)
+                    verify(exactly = 1) { assetCategoryRepository.existsByCode(request.code) }
+                    verify(exactly = 1) { assetCategoryRepository.findByIdOrNull(invalidParentId) }
+                    verify(exactly = 0) { assetCategoryRepository.save(any()) }
+                }
+            }
+
+            When("정상적으로 카테고리 생성이 성공하면") {
+                val request = AssetCategoryCreateRequest("카테고리", "CODE", null, null)
+                val savedCategory = dummyAssetCategory(id = 1L, categoryName = request.name, code = request.code)
+
+                every { assetCategoryRepository.existsByCode(request.code) } returns false
+                every { assetCategoryRepository.save(any()) } returns savedCategory
+
+                val result = service.createAssetCategory(request)
+
+                Then("생성된 카테고리 ID를 반환한다.") {
+                    result shouldBe 1L
+                    verify(exactly = 1) { assetCategoryRepository.existsByCode(request.code) }
+                    verify(exactly = 1) { assetCategoryRepository.save(any()) }
+                    verify(exactly = 0) { fileService.finalizeUpload(any(), any()) }
+                }
+            }
+
+            When("부모 카테고리와 함께 생성하면") {
+                val parentId = 1L
+                val parent = dummyAssetCategory(id = parentId, categoryName = "부모")
+                val request = AssetCategoryCreateRequest("자식", "CHILD_CODE", parentId, null)
+                val savedCategory = dummyAssetCategory(id = 2L, categoryName = request.name, code = request.code)
+                savedCategory.parent = parent
+
+                every { assetCategoryRepository.existsByCode(request.code) } returns false
+                every { assetCategoryRepository.findByIdOrNull(parentId) } returns parent
+                every { assetCategoryRepository.save(any()) } returns savedCategory
+
+                val exception = shouldThrow<CustomException> { service.createAssetCategory(request) }
+
+                Then("EXCEED_CATEGORY_DEPTH 예외가 발생한다.(assetCategory의 MAX_DEPTH = 1)") {
+                    exception.errorCode shouldBe ErrorCode.EXCEED_CATEGORY_DEPTH
+                }
+            }
+
+            When("썸네일 파일 ID와 함께 생성하면") {
+                val thumbnailFileId = 10L
+                val request = AssetCategoryCreateRequest("카테고리", "CODE", null, thumbnailFileId)
+                val savedCategory =
+                    dummyAssetCategory(
+                        id = 1L,
+                        categoryName = request.name,
+                        code = request.code,
+                        iconFileId = thumbnailFileId,
+                    )
+                val fileEntity = FileEntity(originalFileName = "icon.png", filePath = "path", contentType = "image/png")
+
+                every { assetCategoryRepository.existsByCode(request.code) } returns false
+                every { assetCategoryRepository.save(any()) } returns savedCategory
+                every { fileService.finalizeUpload(thumbnailFileId, any()) } returns fileEntity
+
+                val result = service.createAssetCategory(request)
+
+                Then("파일이 finalize되고 카테고리 ID를 반환한다.") {
+                    result shouldBe 1L
+                    verify(exactly = 1) { fileService.finalizeUpload(thumbnailFileId, any()) }
+                }
+            }
+        }
+
+        Given("에셋 카테고리 수정 요청을 할 때") {
+            When("수정 요청한 코드를 가진 카테고리가 이미 존재한다면") {
+                val categoryId = 1L
+                val existingCategory = dummyAssetCategory(id = categoryId, code = "OLD_CODE")
+                val request = AssetCategoryUpdateRequest("카테고리", "NEW_CODE", null, null)
+
+                every { assetCategoryRepository.findByIdOrNull(categoryId) } returns existingCategory
+                every { assetCategoryRepository.existsByCode(request.code) } returns true
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.updateAssetCategory(categoryId, request)
+                    }
+
+                Then("DUPLICATE_ASSET_CATEGORY_CODE 예외가 발생한다.") {
+                    val expectedMessage =
+                        ErrorCode.DUPLICATE_ASSET_CATEGORY_CODE
+                            .getMessage()
+                            .format(request.code)
+
+                    exception.message shouldBe expectedMessage
+
+                    verify(exactly = 1) { assetCategoryRepository.findByIdOrNull(categoryId) }
+                    verify(exactly = 1) { assetCategoryRepository.existsByCode(request.code) }
+                }
+            }
+
+            When("수정 요청한 카테고리가 존재하지 않다면") {
+                val invalidCategoryId = 999L
+                val request = AssetCategoryUpdateRequest("카테고리", "CODE", null, null)
+
+                every { assetCategoryRepository.findByIdOrNull(invalidCategoryId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.updateAssetCategory(invalidCategoryId, request)
+                    }
+
+                Then("NOT_FOUND_CATEGORY 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.NOT_FOUND_CATEGORY.getMessage().format(invalidCategoryId)
+                    verify(exactly = 1) { assetCategoryRepository.findByIdOrNull(invalidCategoryId) }
+                }
+            }
+
+            When("정상적으로 카테고리 수정이 성공하면") {
+                val categoryId = 1L
+                val category = dummyAssetCategory(id = categoryId, categoryName = "이전 이름", code = "OLD_CODE")
+                val request = AssetCategoryUpdateRequest("새 이름", "NEW_CODE", null, null)
+
+                every { assetCategoryRepository.findByIdOrNull(categoryId) } returns category
+                every { assetCategoryRepository.existsByCode(request.code) } returns false
+
+                service.updateAssetCategory(categoryId, request)
+
+                Then("카테고리의 이름과 코드가 요청된 값으로 변경되어야 한다") {
+                    category.code shouldBe "NEW_CODE"
+                    category.name shouldBe request.name
+                }
+            }
+
+            When("썸네일 파일 ID가 변경되면") {
+                val categoryId = 1L
+                val oldThumbnailId = 10L
+                val newThumbnailId = 20L
+                val category = dummyAssetCategory(id = categoryId, code = "CODE", iconFileId = oldThumbnailId)
+                val request =
+                    AssetCategoryUpdateRequest(
+                        "카테고리",
+                        "CODE",
+                        null,
+                        newThumbnailId,
+                    )
+                val fileEntity = FileEntity(originalFileName = "new-icon.png", filePath = "path", contentType = "image/png")
+
+                every { assetCategoryRepository.findByIdOrNull(categoryId) } returns category
+                every { assetCategoryRepository.existsByCode(request.code) } returns false
+                every { fileService.finalizeUpload(newThumbnailId, any()) } returns fileEntity
+
+                service.updateAssetCategory(categoryId, request)
+
+                Then("새로운 파일이 finalize되고 카테고리의 iconFileId가 업데이트된다.") {
+                    category.iconFileId shouldBe newThumbnailId
+                    verify(exactly = 1) { fileService.finalizeUpload(newThumbnailId, any()) }
+                }
+            }
+
+            When("썸네일 파일 ID를 null로 변경하면") {
+                val categoryId = 1L
+                val oldThumbnailId = 10L
+                val category = dummyAssetCategory(id = categoryId, code = "CODE", iconFileId = oldThumbnailId)
+                val request = AssetCategoryUpdateRequest("카테고리", "CODE", null, null)
+
+                every { assetCategoryRepository.findByIdOrNull(categoryId) } returns category
+                every { assetCategoryRepository.existsByCode(request.code) } returns false
+
+                service.updateAssetCategory(categoryId, request)
+
+                Then("카테고리의 iconFileId가 null로 변경된다.") {
+                    category.iconFileId.shouldBeNull()
+                    verify(exactly = 0) { fileService.finalizeUpload(any(), any()) }
+                }
+            }
+        }
+
+        Given("에셋 카테고리 삭제 요청을 할 때") {
+            When("에셋 카테고리 ID가 유효하지 않다면") {
+                val invalidCategoryId = 999L
+
+                every { assetCategoryRepository.findByIdOrNull(invalidCategoryId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.deleteAssetCategory(invalidCategoryId)
+                    }
+
+                Then("NOT_FOUND_CATEGORY 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.NOT_FOUND_CATEGORY.getMessage().format(invalidCategoryId)
+                    verify(exactly = 1) { assetCategoryRepository.findByIdOrNull(invalidCategoryId) }
+                    verify(exactly = 0) { assetCategoryRepository.delete(any()) }
+                }
+            }
+
+            When("카테고리에 에셋이 있다면") {
+                val categoryId = 1L
+                val category = dummyAssetCategory(id = categoryId)
+                val asset = asset.dummyAsset(category = category)
+                category.assets.add(asset)
+
+                every { assetCategoryRepository.findByIdOrNull(categoryId) } returns category
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.deleteAssetCategory(categoryId)
+                    }
+
+                Then("ASSET_CATEGORY_HAS_ASSET 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.ASSET_CATEGORY_HAS_ASSET
+                    verify(exactly = 1) { assetCategoryRepository.findByIdOrNull(categoryId) }
+                    verify(exactly = 0) { assetCategoryRepository.delete(any()) }
+                }
+            }
+
+            When("카테고리에 자식 카테고리가 있다면") {
+                val categoryId = 1L
+                val parentCategory = dummyAssetCategory(id = categoryId)
+                val childCategory = dummyAssetCategory(id = 2L)
+                childCategory.parent = parentCategory
+                parentCategory.children.add(childCategory)
+
+                every { assetCategoryRepository.findByIdOrNull(categoryId) } returns parentCategory
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.deleteAssetCategory(categoryId)
+                    }
+
+                Then("CATEGORY_HAS_CHILDREN 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.CATEGORY_HAS_CHILDREN
+                    verify(exactly = 1) { assetCategoryRepository.findByIdOrNull(categoryId) }
+                    verify(exactly = 0) { assetCategoryRepository.delete(any()) }
+                }
+            }
+
+            When("정상적으로 카테고리 삭제가 성공하면") {
+                val categoryId = 1L
+                val category = dummyAssetCategory(id = categoryId)
+
+                every { assetCategoryRepository.findByIdOrNull(categoryId) } returns category
+                every { assetCategoryRepository.delete(category) } just runs
+
+                service.deleteAssetCategory(categoryId)
+
+                Then("카테고리가 삭제된다.") {
+                    verify(exactly = 1) { assetCategoryRepository.findByIdOrNull(categoryId) }
+                    verify(exactly = 1) { assetCategoryRepository.delete(category) }
+                }
+            }
+        }
+
+        Given("카테고리 깊이 조회 요청을 할 때") {
+            When("정상적으로 호출이 되면") {
+                val result = service.getCategoryDepth()
+
+                Then("MAX_DEPTH를 반환한다.") {
+                    result shouldBe CategoryDepthResponse(com.pluxity.asset.entity.AssetCategory.MAX_DEPTH)
+                }
+            }
+        }
+    })

--- a/common/src/test/kotlin/com/pluxity/asset/AssetCategoryServiceTest.kt
+++ b/common/src/test/kotlin/com/pluxity/asset/AssetCategoryServiceTest.kt
@@ -92,6 +92,13 @@ class AssetCategoryServiceTest
         }
 
         @Test
+        @DisplayName("성공: 전체 카테고리 조회 시 없으면 빈 리스트를 반환한다.")
+        fun getAllCategories_whenNoCategoriesExist_returnsEmptyList() {
+            val rootCategories: List<AssetCategoryResponse> = assetCategoryService.getAllCategories()
+            assertThat(rootCategories).isEmpty()
+        }
+
+        @Test
         @DisplayName("성공: 카테고리의 이름, 코드, 썸네일 정보를 정상적으로 수정한다 (부모 ID는 null)")
         fun updateAssetCategory_withoutParentChange_updatesSuccessfully() {
             val categoryId = createAndSaveCategory("원본", "ORI", null, null)
@@ -116,6 +123,32 @@ class AssetCategoryServiceTest
             val request = AssetCategoryUpdateRequest("이름변경", "CAT_UPDATED", newParentId, null)
 
             assertThrows<CustomException> { assetCategoryService.updateAssetCategory(categoryId, request) }
+        }
+
+        @Test
+        @DisplayName("성공: 카테고리 수정 시 코드가 같을 때는 중복 체크를 하지 않는다")
+        fun updateAssetCategory_withSameCode_doesNotCheckDuplicate() {
+            val categoryId = createAndSaveCategory("카테고리", "CODE", null)
+            val request = AssetCategoryUpdateRequest("새 이름", "CODE", null, null)
+
+            assetCategoryService.updateAssetCategory(categoryId, request)
+
+            val updated = assetCategoryRepository.findById(categoryId).orElseThrow()
+            assertThat(updated.name).isEqualTo("새 이름")
+            assertThat(updated.code).isEqualTo("CODE")
+        }
+
+        @Test
+        @DisplayName("성공: 썸네일을 null로 변경할 수 있다")
+        fun updateAssetCategory_withNullThumbnail_removesThumbnail() {
+            val thumbnailId = testFileUploader.initiateTestFileUpload("icon.png")
+            val categoryId = createAndSaveCategory("카테고리", "CAT", null, thumbnailId)
+            val request = AssetCategoryUpdateRequest("이름", "CAT", null, null)
+
+            assetCategoryService.updateAssetCategory(categoryId, request)
+
+            val updated = assetCategoryRepository.findById(categoryId).orElseThrow()
+            assertThat(updated.iconFileId).isNull()
         }
 
         @Test

--- a/common/src/test/kotlin/com/pluxity/asset/AssetServiceKoTest.kt
+++ b/common/src/test/kotlin/com/pluxity/asset/AssetServiceKoTest.kt
@@ -1,0 +1,380 @@
+package com.pluxity.asset
+
+import asset.dummyAsset
+import asset.dummyAssetCategory
+import com.pluxity.asset.dto.AssetCreateRequest
+import com.pluxity.asset.dto.AssetUpdateRequest
+import com.pluxity.asset.repository.AssetCategoryRepository
+import com.pluxity.asset.repository.AssetRepository
+import com.pluxity.asset.service.AssetCategoryService
+import com.pluxity.asset.service.AssetService
+import com.pluxity.feature.service.FeatureService
+import com.pluxity.file.dto.FileResponse
+import com.pluxity.file.entity.FileEntity
+import com.pluxity.file.service.FileService
+import com.pluxity.global.constant.ErrorCode
+import com.pluxity.global.exception.CustomException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.springframework.data.domain.Sort
+import org.springframework.data.repository.findByIdOrNull
+
+class AssetServiceKoTest :
+    BehaviorSpec({
+
+        isolationMode = IsolationMode.InstancePerLeaf
+
+        val assetRepository = mockk<AssetRepository>()
+        val assetCategoryRepository = mockk<AssetCategoryRepository>()
+        val fileService = mockk<FileService>(relaxed = true)
+        val assetCategoryService = mockk<AssetCategoryService>()
+        val featureService = mockk<FeatureService>()
+
+        val service =
+            AssetService(
+                assetRepository,
+                assetCategoryRepository,
+                fileService,
+                assetCategoryService,
+                featureService,
+            )
+
+        Given("에셋 ID로 단건 조회 요청할 때") {
+            When("ID가 유효하지 않다면") {
+                val invalidID = 999L
+
+                every { assetRepository.findByIdOrNull(invalidID) } returns null
+                val exception =
+                    shouldThrow<CustomException> {
+                        service.findById(invalidID)
+                    }
+                Then("NOT_FOUND_ASSET 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.NOT_FOUND_ASSET.getMessage().format(invalidID)
+                    verify(exactly = 1) { assetRepository.findByIdOrNull(invalidID) }
+                }
+            }
+
+            When("유효한 ID라면") {
+                val validID = 1L
+
+                val assetCategory = dummyAssetCategory(id = 1L, iconFileId = 2L)
+                val asset =
+                    dummyAsset(
+                        id = validID,
+                        category = assetCategory,
+                        name = "test-asset",
+                        code = "test-code",
+                        fileId = null,
+                        thumbnailFileId = null,
+                    )
+
+                every { assetRepository.findByIdOrNull(validID) } returns asset
+
+                val result = service.findById(validID)
+
+                Then("Asset 객체를 반환한다.") {
+                    result.id shouldBe validID
+                    result.category!!.id shouldBe 1L
+                    result.name shouldBe "test-asset"
+                }
+            }
+        }
+
+        Given("에셋 목록 조회를 요청할 때") {
+            val assetCategory = dummyAssetCategory(id = 1L, iconFileId = 2L)
+            val asset1 = dummyAsset(1L, "asset1", "code1", assetCategory, 10L, 20L)
+            val asset2 = dummyAsset(2L, "asset2", "code2", assetCategory, 11L, null)
+            val assets = listOf(asset1, asset2)
+
+            every { assetRepository.findAll(any<Sort>()) } returns assets
+
+            every { fileService.getFiles(any()) } returns
+                listOf(
+                    FileResponse(id = 10L, originalFileName = "test-file-1"),
+                    FileResponse(id = 11L, originalFileName = "test-file-2"),
+                    FileResponse(id = 20L, originalFileName = "test-thumbnail-1"),
+                )
+
+            When("정상적으로 호출이 되면") {
+                val result = service.getAssets()
+
+                Then("에셋 정보와 파일 정보가 매핑된 Response 리스트를 반환한다.") {
+                    result.size shouldBe 2
+                    result[0].file?.id shouldBe 10L
+                    result[0].thumbnailFile?.id shouldBe 20L
+                    result[1].file?.id shouldBe 11L
+                    result[1].thumbnailFile shouldBe null
+
+                    verify(exactly = 1) { assetRepository.findAll(any<Sort>()) }
+                    verify(exactly = 1) { fileService.getFiles(any()) }
+                }
+            }
+        }
+
+        Given("특정 에셋 카테고리에 속한 에셋 조회 요청할 때") {
+            When("카테고리 ID가 유효하고") {
+                var validCategoryId = 1L
+                var category = dummyAssetCategory(id = validCategoryId, iconFileId = 2L)
+
+                And("해당 카테고리에 속한 에셋이 없다면") {
+                    every { assetCategoryService.findById(validCategoryId) } returns category
+                    every { assetRepository.findByCategory(category) } returns emptyList()
+
+                    var result = service.getAssetsByCategory(validCategoryId)
+
+                    Then("빈 리스트를 반환한다.") {
+                        result shouldBe emptyList()
+                    }
+                }
+
+                And("에셋이 있고 모든 파일이 존재한다면") {
+                    val asset = dummyAsset(id = 1L, fileId = 10L, thumbnailFileId = 11L)
+
+                    every { assetCategoryService.findById(validCategoryId) } returns category
+                    every { assetRepository.findByCategory(category) } returns listOf(asset)
+                    every { fileService.getFiles(listOf(10L, 11L)) } returns
+                        listOf(
+                            FileResponse(id = 10L, originalFileName = "test-file-1"),
+                            FileResponse(id = 11L, originalFileName = "test-file-2"),
+                        )
+                    val result = service.getAssetsByCategory(validCategoryId)
+
+                    Then("완전한 AssetResponse 반환") {
+                        result.size shouldBe 1
+                        result[0].file.shouldNotBeNull()
+                        result[0].thumbnailFile.shouldNotBeNull()
+                    }
+                }
+            }
+        }
+
+        Given("에셋 생성 요청 할 때") {
+            When("에셋 name이 중복이라면") {
+                var request = AssetCreateRequest("test-asset", "test-code", null, null, null)
+                every { assetRepository.findByName(request.name) } returns dummyAsset(name = "test-asset")
+
+                var exception =
+                    shouldThrow<CustomException> {
+                        service.createAsset(request)
+                    }
+
+                Then("DUPLICATE_ASSET_NAME 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.DUPLICATE_ASSET_NAME.getMessage().format(request.name)
+                    verify(exactly = 1) { assetRepository.findByName(request.name) }
+                    verify(exactly = 0) { assetRepository.save(any()) }
+                }
+            }
+            When("에셋 코드가 중복이라면") {
+                var request = AssetCreateRequest("test-asset", "test-code", null, null, null)
+                every { assetRepository.findByName(request.name) } returns null
+                every { assetRepository.findByCode(request.code) } returns dummyAsset(name = "test-code")
+
+                var exception =
+                    shouldThrow<CustomException> {
+                        service.createAsset(request)
+                    }
+                Then("DUPLICATE_ASSET_CODE 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.DUPLICATE_ASSET_CODE.getMessage().format(request.code)
+                    verify(exactly = 1) { assetRepository.findByName(request.name) }
+                    verify(exactly = 1) { assetRepository.findByCode(request.code) }
+                    verify(exactly = 0) { assetRepository.save(any()) }
+                }
+            }
+            When("카테고리 ID가 유효하지 않다면") {
+                var invalidCategoryId = 999L
+                var request = AssetCreateRequest("test-asset", "test-code", null, null, invalidCategoryId)
+                every { assetRepository.findByName(request.name) } returns null
+                every { assetRepository.findByCode(request.code) } returns null
+                every { assetCategoryRepository.findByIdOrNull(invalidCategoryId) } returns null
+
+                var exception =
+                    shouldThrow<CustomException> {
+                        service.createAsset(request)
+                    }
+                Then("NOT_FOUND_ASSET_CATEGORY 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.NOT_FOUND_ASSET_CATEGORY.getMessage().format(invalidCategoryId)
+                    verify(exactly = 1) { assetRepository.findByName(request.name) }
+                    verify(exactly = 1) { assetRepository.findByCode(request.code) }
+                    verify(exactly = 1) { assetCategoryRepository.findByIdOrNull(invalidCategoryId) }
+                    verify(exactly = 0) { assetRepository.save(any()) }
+                }
+            }
+
+            When("정상적으로 에셋 생성이 성공하면") {
+                var validCategoryId = 999L
+                var validFileId = 999L
+
+                var request = AssetCreateRequest("test-asset", "test-code", validFileId, null, validCategoryId)
+
+                var category = dummyAssetCategory(id = validCategoryId)
+                var fileEntity = FileEntity(originalFileName = "test-file", filePath = "test-path", contentType = "image/png")
+
+                every { assetRepository.findByName(request.name) } returns null
+                every { assetRepository.findByCode(request.code) } returns null
+                every { assetCategoryRepository.findByIdOrNull(validCategoryId) } returns category
+                every { fileService.finalizeUpload(validFileId, any()) } returns fileEntity
+                every { assetRepository.save(any()) } returns
+                    dummyAsset(id = 1L, name = request.name, code = request.code, category = category, fileId = validFileId)
+
+                var result = service.createAsset(request)
+
+                Then("생성된 에셋 ID를 반환한다.") {
+
+                    result shouldBe 1L
+                    verify(exactly = 1) { assetRepository.save(any()) }
+                }
+            }
+        }
+
+        Given("에셋 수정 요청 할 때") {
+            When("수정 요청한 이름을 가진 에셋이 이미 존재한다면") {
+                var request = AssetUpdateRequest("test-asset", "test-code", null, null, null)
+                var assetId = 1L
+
+                every { assetRepository.findByNameAndIdNot(request.name, assetId) } returns dummyAsset()
+                var exception =
+                    shouldThrow<CustomException> {
+                        service.updateAsset(assetId, request)
+                    }
+
+                Then("DUPLICATE_ASSET_NAME 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.DUPLICATE_ASSET_NAME.getMessage().format(request.name)
+                }
+            }
+
+            When("수정 요청한 코드를 가진 에셋이 이미 존재한다면") {
+                var request = AssetUpdateRequest("test-asset", "test-code", null, null, null)
+                var assetId = 1L
+
+                every { assetRepository.findByNameAndIdNot(request.name, assetId) } returns null
+                every { assetRepository.findByCodeAndIdNot(request.code, assetId) } returns dummyAsset()
+                var exception =
+                    shouldThrow<CustomException> {
+                        service.updateAsset(assetId, request)
+                    }
+
+                Then("DUPLICATE_ASSET_CODE 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.DUPLICATE_ASSET_CODE.getMessage().format(request.code)
+                }
+            }
+
+            When("수정 요청한 에셋이 존재하지 않다면") {
+                var invalidAssetId = 999L
+                var request = AssetUpdateRequest("test-asset", "test-code", null, null, null)
+
+                every { assetRepository.findByNameAndIdNot(request.name, invalidAssetId) } returns null
+                every { assetRepository.findByCodeAndIdNot(request.code, invalidAssetId) } returns null
+                every { assetRepository.findByIdOrNull(invalidAssetId) } returns null
+                var exception =
+                    shouldThrow<CustomException> {
+                        service.updateAsset(invalidAssetId, request)
+                    }
+                Then("NOT_FOUND_ASSET 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.NOT_FOUND_ASSET.getMessage().format(invalidAssetId)
+                }
+            }
+
+            When("카테고리 ID가 유효하지 않다면") {
+                var invalidCategoryId = 999L
+                var request = AssetUpdateRequest("test-asset", "test-code", null, null, invalidCategoryId)
+                var assetId = 1L
+                every { assetRepository.findByNameAndIdNot(request.name, assetId) } returns null
+                every { assetRepository.findByCodeAndIdNot(request.code, assetId) } returns null
+                every { assetRepository.findByIdOrNull(assetId) } returns dummyAsset(id = assetId)
+                every { assetCategoryRepository.findByIdOrNull(invalidCategoryId) } returns null
+
+                var exception = shouldThrow<CustomException> { service.updateAsset(assetId, request) }
+
+                Then("NOT_FOUND_ASSET_CATEGORY 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.NOT_FOUND_ASSET_CATEGORY.getMessage().format(invalidCategoryId)
+                }
+            }
+
+            When("정상적으로 에셋 수정이 성공하면") {
+                var asset = dummyAsset(id = 1L, name = "before-asset", code = "before-code")
+                var validCategoryId = 999L
+                var request = AssetUpdateRequest("after-asset", "after-code", null, null, validCategoryId)
+                var assetId = 1L
+                var category = dummyAssetCategory(id = validCategoryId)
+                every { assetRepository.findByNameAndIdNot(request.name, assetId) } returns null
+                every { assetRepository.findByCodeAndIdNot(request.code, assetId) } returns null
+                every { assetCategoryRepository.findByIdOrNull(validCategoryId) } returns category
+                every { assetRepository.findByIdOrNull(assetId) } returns asset
+
+                service.updateAsset(assetId, request)
+
+                Then("에셋 정보가 정상적으로 업데이트된다.") {
+                    asset.name shouldBe "after-asset"
+                    asset.code shouldBe "after-code"
+                    asset.category shouldBe category
+                }
+            }
+        }
+
+        Given("에셋 삭제 요청 할 때") {
+            When("에셋 ID가 유효하지 않다면") {
+                var invalidAssetId = 999L
+                every { assetRepository.findByIdOrNull(invalidAssetId) } returns null
+
+                var exception = shouldThrow<CustomException> { service.deleteAsset(invalidAssetId) }
+                Then("NOT_FOUND_ASSET 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.NOT_FOUND_ASSET.getMessage().format(invalidAssetId)
+                }
+            }
+
+            When("정상적으로 에셋 삭제가 성공하면") {
+                var validAssetId = 1L
+                var asset = dummyAsset(id = validAssetId, category = dummyAssetCategory(id = 1L))
+
+                every { assetRepository.findByIdOrNull(validAssetId) } returns asset
+                every { featureService.findFeatureIdsByAssetId(validAssetId) } returns emptyList()
+                every { featureService.deleteFeature(any()) } just runs
+                every { assetRepository.delete(asset) } just runs
+
+                service.deleteAsset(validAssetId)
+
+                Then("연관관계 정리 후 삭제 완료") {
+                    asset.category shouldBe null
+                    verify(exactly = 1) { assetRepository.delete(asset) }
+                }
+            }
+        }
+
+        Given("에셋 카테고리 변경 요청 할 때") {
+            When("에셋 ID가 유효하지 않다면") {
+                var invalidAssetId = 999L
+                every { assetRepository.findByIdOrNull(invalidAssetId) } returns null
+
+                var exception = shouldThrow<CustomException> { service.assignCategory(invalidAssetId, 1L) }
+                Then("NOT_FOUND_ASSET 예외가 발생한다.") {
+                    exception.message shouldBe ErrorCode.NOT_FOUND_ASSET.getMessage().format(invalidAssetId)
+                }
+            }
+            When("정상적으로 카테고리 변경이 성공하면") {
+                var validAssetId = 1L
+                var categoryId = 2L
+                var category = dummyAssetCategory(id = 1L, categoryName = "before-category")
+                var assignCategory = dummyAssetCategory(id = 2L, categoryName = "after-category")
+                var asset = dummyAsset(id = validAssetId, category = category)
+
+                every { assetRepository.findByIdOrNull(validAssetId) } returns asset
+                every { assetCategoryService.findById(categoryId) } returns assignCategory
+
+                service.assignCategory(validAssetId, 2L)
+                Then("에셋의 카테고리가 지정한 카테고리로 변경되어야 한다") {
+                    asset.category?.id shouldBe 2L
+                    asset.category?.categoryName shouldBe "after-category"
+                    verify(exactly = 1) { assetRepository.findByIdOrNull(validAssetId) }
+                    verify(exactly = 1) { assetCategoryService.findById(categoryId) }
+                }
+            }
+        }
+    })

--- a/common/src/test/kotlin/com/pluxity/authentication/service/AuthenticationServiceTest.kt
+++ b/common/src/test/kotlin/com/pluxity/authentication/service/AuthenticationServiceTest.kt
@@ -6,10 +6,12 @@ import com.pluxity.authentication.entity.RefreshToken
 import com.pluxity.authentication.repository.RefreshTokenRepository
 import com.pluxity.authentication.security.JwtProvider
 import com.pluxity.config.MockBeansConfig
+import com.pluxity.global.constant.ErrorCode
 import com.pluxity.global.exception.CustomException
 import com.pluxity.global.properties.JwtProperties
 import com.pluxity.user.entity.User
 import com.pluxity.user.repository.UserRepository
+import io.kotest.matchers.shouldBe
 import jakarta.persistence.EntityManager
 import jakarta.servlet.http.Cookie
 import org.assertj.core.api.Assertions
@@ -158,6 +160,17 @@ class AuthenticationServiceTest
             assertThrows<CustomException> {
                 authenticationService.refreshToken(servletRequest, MockHttpServletResponse())
             }
+        }
+
+        @Test
+        @DisplayName("실패: 리프레시 토큰 없이 요청 시 예외가 발생한다.")
+        fun refreshToken_null_shouldThrowException() {
+            val servletRequest = MockHttpServletRequest()
+            val exception =
+                assertThrows<CustomException> {
+                    authenticationService.refreshToken(servletRequest, MockHttpServletResponse())
+                }
+            exception.message shouldBe ErrorCode.INVALID_REFRESH_TOKEN.getMessage()
         }
 
         private fun extractTokenValueFromCookie(

--- a/common/src/test/kotlin/com/pluxity/facility/FacilityHistoryKoTest.kt
+++ b/common/src/test/kotlin/com/pluxity/facility/FacilityHistoryKoTest.kt
@@ -1,0 +1,94 @@
+package com.pluxity.facility
+
+import com.pluxity.facility.history.FacilityHistory
+import com.pluxity.facility.history.FacilityHistoryRepository
+import com.pluxity.facility.history.FacilityHistoryService
+import com.pluxity.file.dto.FileResponse
+import com.pluxity.file.service.FileService
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class FacilityHistoryKoTest :
+    BehaviorSpec({
+
+        val facilityHistoryRepository = mockk<FacilityHistoryRepository>()
+        val fileService = mockk<FileService>()
+        val facilityHistoryService = FacilityHistoryService(facilityHistoryRepository, fileService)
+
+        Given("ID로 조회 요청이 주어질때") {
+            val facilityId = 1L
+            When("해당하는 history를 찾을 수 없다면") {
+                every { facilityHistoryRepository.findByFacilityIdOrderByCreatedAtDesc(facilityId) } returns emptyList()
+                val result = facilityHistoryService.findByFacilityId(facilityId)
+                Then("빈 리스트를 반환한다.") {
+                    result shouldBe emptyList()
+                    verify(exactly = 1) {
+                        facilityHistoryRepository.findByFacilityIdOrderByCreatedAtDesc(facilityId)
+                    }
+                }
+            }
+            When("해당하는 history가 있다면") {
+                val facilityMock1 =
+                    mockk<FacilityHistory>(relaxed = true) {
+                        every { fileId } returns 1L
+                    }
+                val facilityMock2 =
+                    mockk<FacilityHistory>(relaxed = true) {
+                        every { fileId } returns 2L
+                    }
+
+                val fileResponse1 =
+                    mockk<FileResponse>(relaxed = true) {
+                        every { id } returns 1L
+                    }
+                val fileResponse2 =
+                    mockk<FileResponse>(relaxed = true) {
+                        every { id } returns 2L
+                    }
+
+                every {
+                    facilityHistoryRepository.findByFacilityIdOrderByCreatedAtDesc(facilityId)
+                } returns listOf(facilityMock1, facilityMock2)
+
+                every {
+                    fileService.getFiles(listOf(1L, 2L))
+                } returns listOf(fileResponse1, fileResponse2)
+
+                val result = facilityHistoryService.findByFacilityId(facilityId)
+
+                Then("FacilityHistoryResponse 리스트를 반환한다.") {
+                    result.size shouldBe 2
+                    result[0].file shouldBe fileResponse1
+                    result[1].file shouldBe fileResponse2
+                }
+            }
+            When("해당하는 history가 있지만 파일을 찾을 수 없다면") {
+                val facilityMock1 =
+                    mockk<FacilityHistory>(relaxed = true) {
+                        every { fileId } returns 1L
+                    }
+
+                every {
+                    facilityHistoryRepository.findByFacilityIdOrderByCreatedAtDesc(facilityId)
+                } returns listOf(facilityMock1)
+
+                every {
+                    fileService.getFiles(any<List<Long>>())
+                } returns emptyList()
+
+                Then("빈 리스트를 반환한다") {
+                    val result = facilityHistoryService.findByFacilityId(facilityId)
+                    result shouldBe emptyList()
+                    verify(exactly = 1) {
+                        facilityHistoryRepository.findByFacilityIdOrderByCreatedAtDesc(facilityId)
+                    }
+                    verify(exactly = 1) {
+                        fileService.getFiles(any<List<Long>>())
+                    }
+                }
+            }
+        }
+    })

--- a/common/src/test/kotlin/com/pluxity/facility/FacilityPathKoTest.kt
+++ b/common/src/test/kotlin/com/pluxity/facility/FacilityPathKoTest.kt
@@ -1,0 +1,172 @@
+package com.pluxity.facility
+
+import com.pluxity.facility.path.FacilityPath
+import com.pluxity.facility.path.FacilityPathRepository
+import com.pluxity.facility.path.FacilityPathService
+import com.pluxity.facility.path.PathType
+import com.pluxity.global.constant.ErrorCode
+import com.pluxity.global.exception.CustomException
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import org.springframework.data.repository.findByIdOrNull
+
+class FacilityPathKoTest :
+    BehaviorSpec({
+
+        val facilityPathRepository = mockk<FacilityPathRepository>()
+        val service = FacilityPathService(facilityPathRepository)
+
+        val invalidId = -1L
+        val validId = 1L
+
+        Given("조회 요청이 주어지고") {
+            When("유효하지 않은 id로 조회시") {
+                every { facilityPathRepository.findByIdOrNull(invalidId) } returns null
+                Then("NOT_FOUND_FACILITY_PATH 예외가 발생한다.") {
+                    val exception =
+                        shouldThrowExactly<CustomException> {
+                            service.findById(invalidId)
+                        }
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY_PATH
+                    exception.message shouldBe ErrorCode.NOT_FOUND_FACILITY_PATH.getMessage().format(invalidId)
+                    verify(exactly = 1) { facilityPathRepository.findByIdOrNull(invalidId) }
+                }
+            }
+
+            When("유효한 id로 조회시") {
+                val facilityPath = mockk<FacilityPath> { every { id } returns validId }
+                every { facilityPathRepository.findByIdOrNull(validId) } returns facilityPath
+                val result = service.findById(validId)
+                Then("엔티티를 반환한다.") {
+                    result.id shouldBe validId
+                    verify(exactly = 1) { facilityPathRepository.findByIdOrNull(validId) }
+                }
+            }
+        }
+
+        Given("수정 요청이 주어지고") {
+            When("유효하지 않은 id로 수정 시") {
+                every { facilityPathRepository.findByIdOrNull(invalidId) } returns null
+                Then("NOT_FOUND_FACILITY_PATH 예외가 발생한다.") {
+                    val exception =
+                        shouldThrowExactly<CustomException> {
+                            service.update(invalidId, null, null, null)
+                        }
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY_PATH
+                    exception.message shouldBe ErrorCode.NOT_FOUND_FACILITY_PATH.getMessage().format(invalidId)
+                    verify(exactly = 1) { facilityPathRepository.findByIdOrNull(invalidId) }
+                }
+            }
+
+            When("name이 공백일 경우") {
+                val updateName = ""
+                val testFacilityPath =
+                    FacilityPath(
+                        name = "test-name",
+                        pathType = PathType.WAY,
+                        path = "test-path",
+                    )
+
+                every { facilityPathRepository.findByIdOrNull(invalidId) } returns testFacilityPath
+                service.update(invalidId, updateName, null, null)
+                Then(" 수정 되지 않는다.") {
+                    testFacilityPath.name shouldBe "test-name"
+                    verify(exactly = 1) { facilityPathRepository.findByIdOrNull(invalidId) }
+                }
+            }
+
+            When("name이 공백이 아닐경우") {
+                val updatedName = "update-name"
+                val testFacilityPath =
+                    FacilityPath(
+                        name = "test-name",
+                        pathType = PathType.WAY,
+                        path = "test-path",
+                    )
+
+                every { facilityPathRepository.findByIdOrNull(validId) } returns testFacilityPath
+                service.update(validId, updatedName, null, null)
+                Then("수정에 성공한다.") {
+                    testFacilityPath.name shouldBe updatedName
+                    verify(exactly = 1) { facilityPathRepository.findByIdOrNull(validId) }
+                }
+            }
+
+            When("pathType이 잘못된 경우") {
+                val invalidPathType = "invalid-path-type"
+                val testFacilityPath =
+                    FacilityPath(
+                        name = "test-name",
+                        pathType = PathType.WAY,
+                        path = "test-path",
+                    )
+
+                every { facilityPathRepository.findByIdOrNull(validId) } returns testFacilityPath
+
+                val exception =
+                    shouldThrowExactly<CustomException> {
+                        service.update(validId, null, invalidPathType, null)
+                    }
+
+                Then("NOT_FOUND_PATH_TYPE 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_PATH_TYPE
+                    exception.message shouldBe ErrorCode.NOT_FOUND_PATH_TYPE.getMessage().format(invalidPathType)
+                    verify(exactly = 1) { facilityPathRepository.findByIdOrNull(validId) }
+                }
+            }
+
+            When("여러 필드를 동시에 수정할 경우") {
+                val updateName = "update-name"
+                val updatePath = "update-path"
+                val updatePathType = PathType.PATROL
+                val testFacilityPath =
+                    FacilityPath(
+                        name = "test-name",
+                        pathType = PathType.WAY,
+                        path = "test-path",
+                    )
+
+                every { facilityPathRepository.findByIdOrNull(validId) } returns testFacilityPath
+                service.update(validId, updateName, updatePathType.name, updatePath)
+                Then("수정에 성공한다.") {
+                    testFacilityPath.name shouldBe updateName
+                    testFacilityPath.path shouldBe updatePath
+                    testFacilityPath.pathType shouldBe updatePathType
+                    verify(exactly = 1) { facilityPathRepository.findByIdOrNull(validId) }
+                }
+            }
+        }
+
+        Given("삭제 요청이 주어지고") {
+            When("유효하지 않은 id로 삭제 시") {
+                every { facilityPathRepository.findByIdOrNull(invalidId) } returns null
+                val exception =
+                    shouldThrowExactly<CustomException> {
+                        service.delete(invalidId)
+                    }
+                Then("NOT_FOUND_FACILITY_PATH 예외가 발생한다") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY_PATH
+                    verify(exactly = 1) { facilityPathRepository.findByIdOrNull(invalidId) }
+                    verify(exactly = 0) { facilityPathRepository.delete(any()) }
+                }
+            }
+
+            When("유효한 id로 삭제 시") {
+                val facilityPath = mockk<FacilityPath>()
+                every { facilityPathRepository.findByIdOrNull(validId) } returns facilityPath
+                every { facilityPathRepository.delete(facilityPath) } just runs
+
+                Then("정상적으로 삭제된다.") {
+                    service.delete(validId)
+                    verify(exactly = 1) { facilityPathRepository.delete(facilityPath) }
+                    verify(exactly = 1) { facilityPathRepository.findByIdOrNull(validId) }
+                }
+            }
+        }
+    })

--- a/common/src/test/kotlin/com/pluxity/facility/FacilityServiceKoTest.kt
+++ b/common/src/test/kotlin/com/pluxity/facility/FacilityServiceKoTest.kt
@@ -1,0 +1,690 @@
+package com.pluxity.facility
+
+import base.entity.withAudit
+import base.entity.withId
+import com.pluxity.facility.dto.FacilityCreateRequest
+import com.pluxity.facility.dto.FacilityDrawingUpdateRequest
+import com.pluxity.facility.dto.FacilityFloorUpdateRequest
+import com.pluxity.facility.dto.FacilityLocationUpdateRequest
+import com.pluxity.facility.dto.FacilityPathSaveRequest
+import com.pluxity.facility.dto.FacilityPathUpdateRequest
+import com.pluxity.facility.dto.FacilityUpdateRequest
+import com.pluxity.facility.history.FacilityHistoryService
+import com.pluxity.facility.path.FacilityPathService
+import com.pluxity.facility.strategy.FloorService
+import com.pluxity.file.dto.FileResponse
+import com.pluxity.file.entity.FileEntity
+import com.pluxity.file.service.FileService
+import com.pluxity.global.constant.ErrorCode
+import com.pluxity.global.exception.CustomException
+import facility.dummyCreateFacilityRequest
+import facility.dummyUpdateFacilityRequest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import org.springframework.data.repository.findByIdOrNull
+
+class FacilityServiceKoTest :
+    BehaviorSpec({
+
+        isolationMode = IsolationMode.InstancePerLeaf
+
+        val facilityRepository = mockk<FacilityRepository>()
+        val fileService = mockk<FileService>(relaxed = true)
+        val facilityHistoryService = mockk<FacilityHistoryService>()
+        val facilityPathService = mockk<FacilityPathService>()
+        val floorService = mockk<FloorService>()
+
+        val facilityService =
+            FacilityService(
+                facilityRepository,
+                fileService,
+                facilityHistoryService,
+                facilityPathService,
+                floorService,
+            )
+
+        Given("시설 생성 요청을 할 때") {
+            When("코드가 중복이라면") {
+                val request = dummyCreateFacilityRequest()
+                val facility = FacilityInstance(request.name)
+
+                every { facilityRepository.existsByCode(request.code) } returns true
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.save(facility, request)
+                    }
+
+                Then("DUPLICATE_FACILITY_CODE 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.DUPLICATE_FACILITY_CODE
+                    verify(exactly = 1) { facilityRepository.existsByCode(request.code) }
+                    verify(exactly = 0) { facilityRepository.save(any()) }
+                }
+            }
+
+            When("정상적으로 시설 생성이 성공하면") {
+                val generatedId = 100L
+                val drawingFileId = 10L
+                val thumbnailFileId = 20L
+
+                val request = FacilityCreateRequest("시설", "CODE", "설명", drawingFileId, thumbnailFileId, null, null, null)
+                val facility = FacilityInstance(request.name)
+                val savedFacility = FacilityInstance(request.name, request.code).withId(generatedId)
+
+                val drawingFile = mockk<FileEntity> { every { id } returns request.drawingFileId!! }
+                val thumbnailFile = mockk<FileEntity> { every { id } returns request.thumbnailFileId!! }
+
+                every { facilityRepository.existsByCode(request.code) } returns false
+                every { facilityRepository.save(any<Facility>()) } returns savedFacility
+
+                every { fileService.finalizeUpload(any(), any()) } returnsMany listOf(drawingFile, thumbnailFile)
+                every { facilityHistoryService.save(any(), any(), any()) } just runs
+
+                val result = facilityService.save(facility, request)
+
+                Then("저장된 시설을 반환하며 ID와 파일 경로가 올바르게 전파된다.") {
+                    result shouldBe savedFacility
+
+                    val expectedPath = "facilities/$generatedId/"
+
+                    verify(exactly = 1) {
+                        fileService.finalizeUpload(request.drawingFileId!!, match { it == expectedPath })
+                    }
+                    verify(exactly = 1) {
+                        fileService.finalizeUpload(request.thumbnailFileId!!, match { it == expectedPath })
+                    }
+
+                    verify(exactly = 1) {
+                        facilityHistoryService.save(request.drawingFileId!!, generatedId, "최초등록")
+                    }
+                }
+            }
+
+            When("도면 파일 ID가 있으면") {
+                val drawingFileId = 10L
+                val request = FacilityCreateRequest("시설", "CODE", "설명", drawingFileId, null, null, null, null)
+                val facility = FacilityInstance(request.name)
+                val savedFacility = FacilityInstance(request.name, request.code).withId(1L)
+                val fileEntity = mockk<FileEntity> { every { id } returns drawingFileId }
+
+                every { facilityRepository.existsByCode(request.code) } returns false
+                every { facilityRepository.save(any<Facility>()) } returns savedFacility
+                every { fileService.finalizeUpload(drawingFileId, any<String>()) } returns fileEntity
+                every { facilityHistoryService.save(drawingFileId, 1L, "최초등록") } just runs
+
+                facilityService.save(facility, request)
+
+                Then("히스토리가 저장된다.") {
+                    verify(exactly = 1) { facilityHistoryService.save(drawingFileId, 1L, "최초등록") }
+                }
+            }
+
+            When("도면 파일 ID가 없으면") {
+                val request = FacilityCreateRequest("시설", "CODE", "설명", null, null, null, null, null)
+                val facility = FacilityInstance(request.name)
+                val savedFacility = FacilityInstance(request.name, request.code).withId(1L)
+
+                every { facilityRepository.existsByCode(request.code) } returns false
+                every { facilityRepository.save(any<Facility>()) } returns savedFacility
+
+                facilityService.save(facility, request)
+
+                Then("히스토리가 저장되지 않는다.") {
+                    verify(exactly = 0) { facilityHistoryService.save(any<Long>(), any<Long>(), any<String>()) }
+                }
+            }
+
+            When("썸네일 파일 ID만 있으면") {
+                val thumbnailFileId = 10L
+                val request = FacilityCreateRequest("시설", "CODE", "설명", null, thumbnailFileId, null, null, null)
+                val facility = FacilityInstance(request.name)
+                val savedFacility = FacilityInstance(request.name, request.code).withId(1L)
+                val fileEntity = mockk<FileEntity> { every { id } returns thumbnailFileId }
+
+                every { facilityRepository.existsByCode(request.code) } returns false
+                every { facilityRepository.save(any<Facility>()) } returns savedFacility
+                every { fileService.finalizeUpload(thumbnailFileId, any<String>()) } returns fileEntity
+
+                facilityService.save(facility, request)
+
+                Then("히스토리가 저장되지 않는다.") {
+                    verify(exactly = 0) { facilityHistoryService.save(thumbnailFileId, 1L, "최초등록") }
+                }
+            }
+
+            When("위치 정보(Position)가 포함되어 있으면") {
+                val request = FacilityCreateRequest("시설", "CODE", "설명", null, null, 127.0, 37.0, "정문 앞")
+                val facility = FacilityInstance(request.name)
+                val savedFacility = FacilityInstance(request.name, request.code).withId(1L)
+
+                every { facilityRepository.existsByCode(request.code) } returns false
+                every { facilityRepository.save(any<Facility>()) } returns savedFacility
+
+                // When
+                facilityService.save(facility, request)
+
+                Then("엔티티의 위치 정보가 업데이트된다.") {
+                    facility.position?.lon shouldBe 127.0
+                    facility.position?.lat shouldBe 37.0
+                    facility.position?.locationMeta shouldBe "정문 앞"
+                }
+            }
+        }
+
+        Given("코드로 시설 조회 요청을 할 때") {
+            When("코드가 유효하다면") {
+                val code = "VALID_CODE"
+                val facility = FacilityInstance("시설", code)
+
+                every { facilityRepository.findByCode(code) } returns facility
+
+                val result = facilityService.findByCode(code)
+
+                Then("시설을 반환한다.") {
+                    result shouldBe facility
+                    verify(exactly = 1) { facilityRepository.findByCode(code) }
+                }
+            }
+
+            When("코드가 유효하지 않다면") {
+                val invalidCode = "INVALID_CODE"
+
+                every { facilityRepository.findByCode(invalidCode) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.findByCode(invalidCode)
+                    }
+
+                Then("NOT_FOUND_FACILITY_CODE 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY_CODE
+                    verify(exactly = 1) { facilityRepository.findByCode(invalidCode) }
+                }
+            }
+        }
+
+        Given("ID로 시설 조회 요청을 할 때") {
+            When("ID가 유효하다면") {
+                val id = 1L
+                val facility = FacilityInstance("시설", "CODE").withId(id)
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+
+                val result = facilityService.findById(id)
+
+                Then("시설을 반환한다.") {
+                    result shouldBe facility
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(id) }
+                }
+            }
+
+            When("ID가 유효하지 않다면") {
+                val invalidId = 999L
+
+                every { facilityRepository.findByIdOrNull(invalidId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.findById(invalidId)
+                    }
+
+                Then("NOT_FOUND_FACILITY 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY
+                    exception.message shouldBe ErrorCode.NOT_FOUND_FACILITY.getMessage().format(invalidId)
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(invalidId) }
+                }
+            }
+        }
+
+        Given("시설 수정 요청을 할 때") {
+            When("수정 요청한 코드가 중복이라면") {
+                val id = 1L
+                val facility = FacilityInstance("시설", "OLD_CODE").withId(id)
+                val newCode = "NEW_CODE"
+                val request = FacilityUpdateRequest("시설", newCode, null, null, null, null, null)
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+                every { facilityRepository.existsByCode(newCode) } returns true
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.update(id, request)
+                    }
+
+                Then("DUPLICATE_FACILITY_CODE 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.DUPLICATE_FACILITY_CODE
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(id) }
+                    verify(exactly = 1) { facilityRepository.existsByCode(newCode) }
+                }
+            }
+
+            When("정상적으로 시설 수정이 성공하면") {
+                val id = 1L
+                val request = dummyUpdateFacilityRequest()
+                val facility = FacilityInstance("시설", request.code).withId(id)
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+                every { facilityRepository.existsByCode(request.code!!) } returns false
+
+                facilityService.update(id, request)
+
+                Then("시설 정보가 업데이트된다.") {
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(id) }
+                }
+            }
+
+            When("썸네일 파일 ID가 변경되면") {
+                val id = 1L
+                val oldThumbnailId = 10L
+                val newThumbnailId = 20L
+                val request = FacilityUpdateRequest("시설", null, null, newThumbnailId, null, null, null)
+                val facility = FacilityInstance("시설", null, null, null, null, oldThumbnailId).withId(id)
+                val fileEntity = mockk<FileEntity>()
+                every { fileEntity.id } returns newThumbnailId
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+                every { fileService.finalizeUpload(newThumbnailId, any()) } returns fileEntity
+
+                facilityService.update(id, request)
+
+                Then("새로운 파일이 finalize된다.") {
+                    verify(exactly = 1) { fileService.finalizeUpload(newThumbnailId, any()) }
+                    facility.thumbnailFileId shouldBe newThumbnailId
+                }
+            }
+
+            When("썸네일 파일 ID가 동일하면") {
+                val id = 1L
+                val thumbnailId = 10L
+                val request = FacilityUpdateRequest("시설", null, null, thumbnailId, null, null, null)
+                val facility = FacilityInstance("시설", null, null, null, null, thumbnailId).withId(id)
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+
+                facilityService.update(id, request)
+
+                Then("파일이 finalize되지 않는다.") {
+                    verify(exactly = 0) { fileService.finalizeUpload(any(), any()) }
+                }
+            }
+        }
+
+        Given("시설 전체 수정 요청을 할 때") {
+            When("정상적으로 시설 전체 수정이 성공하면") {
+                val id = 1L
+                val request = dummyUpdateFacilityRequest()
+                val facility = FacilityInstance("시설", "OLD_CODE").withId(id)
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+                every { facilityRepository.existsByCode(request.code!!) } returns false
+
+                facilityService.putUpdate(id, request)
+
+                Then("시설 정보가 전체 업데이트된다.") {
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(id) }
+                }
+            }
+
+            When("썸네일 파일 ID를 null로 변경하면") {
+                val id = 1L
+                val request = FacilityUpdateRequest("시설", null, null, null, null, null, null)
+                val facility = FacilityInstance("시설", null, null, null, null, 10L).withId(id)
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+
+                facilityService.putUpdate(id, request)
+
+                Then("썸네일 파일 ID가 null로 설정된다.") {
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(id) }
+                }
+            }
+        }
+
+        Given("시설 삭제 요청을 할 때") {
+            When("ID가 유효하지 않다면") {
+                val invalidId = 999L
+
+                every { facilityRepository.findByIdOrNull(invalidId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.deleteFacility(invalidId)
+                    }
+
+                Then("NOT_FOUND_FACILITY 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(invalidId) }
+                    verify(exactly = 0) { facilityRepository.delete(any()) }
+                }
+            }
+
+            When("정상적으로 시설 삭제가 성공하면") {
+                val id = 1L
+                val facility = FacilityInstance("시설", "CODE").withId(id)
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+                every { facilityRepository.delete(facility) } just runs
+
+                facilityService.deleteFacility(id)
+
+                Then("시설이 삭제된다.") {
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(id) }
+                    verify(exactly = 1) { facilityRepository.delete(facility) }
+                }
+            }
+        }
+
+        Given("시설 히스토리 조회 요청을 할 때") {
+            When("시설 ID가 유효하지 않다면") {
+                val invalidId = 999L
+
+                every { facilityRepository.findByIdOrNull(invalidId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.findFacilityHistories(invalidId)
+                    }
+
+                Then("NOT_FOUND_FACILITY 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(invalidId) }
+                    verify(exactly = 0) { facilityHistoryService.findByFacilityId(any()) }
+                }
+            }
+
+            When("정상적으로 히스토리 조회가 성공하면") {
+                val id = 1L
+                val facility = FacilityInstance("시설", "CODE").withId(id)
+                val histories = emptyList<com.pluxity.facility.dto.FacilityHistoryResponse>()
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+                every { facilityHistoryService.findByFacilityId(id) } returns histories
+
+                val result = facilityService.findFacilityHistories(id)
+
+                Then("히스토리 리스트를 반환한다.") {
+                    result shouldBe histories
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(id) }
+                    verify(exactly = 1) { facilityHistoryService.findByFacilityId(id) }
+                }
+            }
+        }
+
+        Given("도면 파일 수정 요청을 할 때") {
+            When("시설 ID가 유효하지 않다면") {
+                val invalidId = 999L
+                val request = FacilityDrawingUpdateRequest(10L, "주석")
+
+                every { facilityRepository.findByIdOrNull(invalidId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.updateDrawingFile(invalidId, request)
+                    }
+
+                Then("NOT_FOUND_FACILITY 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(invalidId) }
+                    verify(exactly = 0) { fileService.finalizeUpload(any(), any()) }
+                }
+            }
+
+            When("정상적으로 도면 파일 수정이 성공하면") {
+                val id = 1L
+                val facility = FacilityInstance("시설", "CODE").withId(id).withAudit()
+                val request = FacilityDrawingUpdateRequest(10L, "주석")
+                val fileEntity = mockk<FileEntity>()
+
+                every { fileEntity.id } returns request.drawingFileId
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+                every { fileService.finalizeUpload(request.drawingFileId, any()) } returns fileEntity
+                every { facilityHistoryService.save(request.drawingFileId, id, request.comment ?: "") } just runs
+
+                facilityService.updateDrawingFile(id, request)
+
+                Then("도면 파일이 업데이트되고 히스토리가 저장된다.") {
+                    verify(exactly = 1) { fileService.finalizeUpload(request.drawingFileId, any()) }
+                    verify(exactly = 1) { facilityHistoryService.save(request.drawingFileId, id, request.comment ?: "") }
+                }
+            }
+        }
+
+        Given("시설 경로 저장 요청을 할 때") {
+            When("시설 ID가 유효하지 않다면") {
+                val invalidId = 999L
+                val request = FacilityPathSaveRequest("경로명", "SUBWAY", "{}")
+
+                every { facilityRepository.findByIdOrNull(invalidId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.savePath(invalidId, request)
+                    }
+
+                Then("NOT_FOUND_FACILITY 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(invalidId) }
+                    verify(exactly = 0) { facilityPathService.save(any(), any(), any(), any()) }
+                }
+            }
+
+            When("정상적으로 경로 저장이 성공하면") {
+                val id = 1L
+                val facility = FacilityInstance("시설", "CODE").withId(id)
+                val request = FacilityPathSaveRequest("경로명", "SUBWAY", "{}")
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+                every { facilityPathService.save(facility, request.name, request.type, request.path) } just runs
+
+                facilityService.savePath(id, request)
+
+                Then("경로가 저장된다.") {
+                    verify(exactly = 1) { facilityPathService.save(facility, request.name, request.type, request.path) }
+                }
+            }
+        }
+
+        Given("시설 경로 수정 요청을 할 때") {
+            When("시설 ID가 유효하지 않다면") {
+                val invalidId = 999L
+                val pathId = 1L
+                val request = FacilityPathUpdateRequest("수정경로명", "WAY", "{}")
+
+                every { facilityRepository.findByIdOrNull(invalidId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.updatePath(invalidId, pathId, request)
+                    }
+
+                Then("NOT_FOUND_FACILITY 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(invalidId) }
+                    verify(exactly = 0) { facilityPathService.update(any(), any(), any(), any()) }
+                }
+            }
+
+            When("정상적으로 경로 수정이 성공하면") {
+                val id = 1L
+                val pathId = 1L
+                val facility = FacilityInstance("시설", "CODE").withId(id)
+                val request = FacilityPathUpdateRequest("수정경로명", "WAY", "{}")
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+                every { facilityPathService.update(pathId, request.name, request.type, request.path) } just runs
+
+                facilityService.updatePath(id, pathId, request)
+
+                Then("경로가 수정된다.") {
+                    verify(exactly = 1) { facilityPathService.update(pathId, request.name, request.type, request.path) }
+                }
+            }
+        }
+
+        Given("시설 경로 삭제 요청을 할 때") {
+            When("시설 ID가 유효하지 않다면") {
+                val invalidId = 999L
+                val pathId = 1L
+
+                every { facilityRepository.findByIdOrNull(invalidId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.deletePath(invalidId, pathId)
+                    }
+
+                Then("NOT_FOUND_FACILITY 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(invalidId) }
+                    verify(exactly = 0) { facilityPathService.delete(any()) }
+                }
+            }
+
+            When("정상적으로 경로 삭제가 성공하면") {
+                val id = 1L
+                val pathId = 1L
+                val facility = FacilityInstance("시설", "CODE").withId(id)
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+                every { facilityPathService.delete(pathId) } just runs
+
+                facilityService.deletePath(id, pathId)
+
+                Then("경로가 삭제된다.") {
+                    verify(exactly = 1) { facilityPathService.delete(pathId) }
+                }
+            }
+        }
+
+        Given("시설 위치 수정 요청을 할 때") {
+            When("시설 ID가 유효하지 않다면") {
+                val invalidId = 999L
+                val request = FacilityLocationUpdateRequest(127.0, 37.0, "{}")
+
+                every { facilityRepository.findByIdOrNull(invalidId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.updateLocation(invalidId, request)
+                    }
+
+                Then("NOT_FOUND_FACILITY 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(invalidId) }
+                }
+            }
+
+            When("정상적으로 위치 수정이 성공하면") {
+                val id = 1L
+                val facility = FacilityInstance("시설", "CODE").withId(id)
+                val request = FacilityLocationUpdateRequest(127.0, 37.0, "{}")
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+
+                facilityService.updateLocation(id, request)
+
+                Then("위치가 업데이트된다.") {
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(id) }
+                }
+            }
+        }
+
+        Given("시설 층 수정 요청을 할 때") {
+            When("시설 ID가 유효하지 않다면") {
+                val invalidId = 999L
+                val request = FacilityFloorUpdateRequest(emptyList())
+
+                every { facilityRepository.findByIdOrNull(invalidId) } returns null
+
+                val exception =
+                    shouldThrow<CustomException> {
+                        facilityService.updateFloor(invalidId, request)
+                    }
+
+                Then("NOT_FOUND_FACILITY 예외가 발생한다.") {
+                    exception.errorCode shouldBe ErrorCode.NOT_FOUND_FACILITY
+                    verify(exactly = 1) { facilityRepository.findByIdOrNull(invalidId) }
+                    verify(exactly = 0) { floorService.update(any(), any()) }
+                }
+            }
+
+            When("정상적으로 층 수정이 성공하면") {
+                val id = 1L
+                val facility = FacilityInstance("시설", "CODE").withId(id)
+                val request = FacilityFloorUpdateRequest(emptyList())
+
+                every { facilityRepository.findByIdOrNull(id) } returns facility
+                every { floorService.update(facility, request.floors) } just runs
+
+                facilityService.updateFloor(id, request)
+
+                Then("층이 업데이트된다.") {
+                    verify(exactly = 1) { floorService.update(facility, request.floors) }
+                }
+            }
+        }
+
+        Given("시설 목록 조회 요청을 할 때") {
+            When("정상적으로 조회가 성공하면") {
+                val facility1 = FacilityInstance("시설1", "CODE1", null, null, 10L, 20L).withId(1L).withAudit()
+                val facility2 = FacilityInstance("시설2", "CODE2").withId(2L).withAudit()
+                val facilities = listOf(facility1, facility2)
+
+                every { facilityRepository.findAllByOrderByCreatedAtDesc() } returns facilities
+                every { fileService.getFiles(any<List<Long>>()) } returns emptyList<FileResponse>()
+
+                val result = facilityService.findAllFacilities()
+
+                Then("시설 목록을 반환한다.") {
+                    result.size shouldBe 2
+                    verify(exactly = 1) { facilityRepository.findAllByOrderByCreatedAtDesc() }
+                    verify(exactly = 1) { fileService.getFiles(any<List<Long>>()) }
+                }
+            }
+
+            When("데이터가 없으면") {
+                every { facilityRepository.findAllByOrderByCreatedAtDesc() } returns emptyList()
+
+                val result = facilityService.findAllFacilities()
+
+                Then("빈 리스트를 반환한다.") {
+                    result shouldBe emptyList()
+                    verify(exactly = 1) { facilityRepository.findAllByOrderByCreatedAtDesc() }
+                }
+            }
+        }
+    }) {
+    @Entity
+    @DiscriminatorValue("TEST")
+    class FacilityInstance(
+        name: String,
+        code: String? = null,
+        description: String? = null,
+        historyComment: String? = null,
+        drawingFileId: Long? = null,
+        thumbnailFileId: Long? = null,
+        position: FacilityPosition? = null,
+        category: com.pluxity.facility.category.FacilityCategory? = null,
+    ) : Facility(
+            name = name,
+            code = code,
+            description = description,
+            historyComment = historyComment,
+            drawingFileId = drawingFileId,
+            thumbnailFileId = thumbnailFileId,
+            position = position,
+        ) {
+        init {
+            category?.let { assignCategory(it) }
+        }
+    }
+}

--- a/common/src/test/kotlin/com/pluxity/facility/FacilityServiceTest.kt
+++ b/common/src/test/kotlin/com/pluxity/facility/FacilityServiceTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
@@ -120,6 +121,45 @@ class FacilityServiceTest
         }
 
         @Test
+        @DisplayName("도면 파일 없이 시설 생성 요청 시 히스토리가 등록되지 않는다.")
+        fun `save without drawingFile request save facility`() {
+            val drawingFileId = null
+            val thumbnailFileId = testFileUploader.initiateTestFileUpload("thumb.png")
+            val request =
+                FacilityCreateRequest(
+                    name = "서울역",
+                    code = "SEOUL_ST",
+                    description = "대한민국 수도의 관문",
+                    drawingFileId = drawingFileId,
+                    thumbnailFileId = thumbnailFileId,
+                    lon = 126.97,
+                    lat = 37.55,
+                    locationMeta = "{'floor': 5}",
+                )
+            val facility =
+                FacilityInstance(
+                    name = request.name,
+                    code = request.code,
+                    description = request.description,
+                    drawingFileId = request.drawingFileId,
+                    thumbnailFileId = request.thumbnailFileId,
+                )
+
+            // when
+            val savedFacility = facilityService.save(facility, request)
+
+            // then
+            verify(facilityHistoryService, never()).save(
+                fileId = any(),
+                facilityId = any(),
+                comment = any(),
+            )
+
+            savedFacility.shouldNotBeNull()
+            savedFacility.name shouldBe "서울역"
+        }
+
+        @Test
         @DisplayName("실패: 중복된 코드로 시설 생성 시 예외가 발생한다")
         fun `save with duplicate code throws CustomException`() {
             // GIVEN
@@ -189,6 +229,25 @@ class FacilityServiceTest
             updated.code shouldBe "UPD_CODE"
             updated.description shouldBe null
             updated.position?.lat shouldBe 2.0
+        }
+
+        @Test
+        @DisplayName("성공: update 요청 시 code가 같을때는 중복 체크를 하지 않는다.")
+        fun `update with same code does not check for duplicate`() {
+            // Given
+            val saved =
+                facilityService.save(
+                    FacilityInstance("원본 이름", "ORI_CODE", "원본 설명", null, null),
+                    FacilityCreateRequest("원본 이름", "ORI_CODE", "원본 설명", null, null, 1.0, 1.0, null),
+                )
+
+            val request = FacilityUpdateRequest("수정된 이름", "ORI_CODE", null, null, 2.0, null, null)
+
+            facilityService.update(saved.requiredId, request)
+
+            val updated = facilityService.findById(saved.requiredId)
+            updated.code shouldBe "ORI_CODE"
+            updated.name shouldBe "수정된 이름"
         }
 
         @Test

--- a/common/src/test/kotlin/com/pluxity/facility/FacilityServiceTest.kt
+++ b/common/src/test/kotlin/com/pluxity/facility/FacilityServiceTest.kt
@@ -251,6 +251,26 @@ class FacilityServiceTest
         }
 
         @Test
+        @DisplayName("성공: update 요청 시 thumbnailFileId가 같을 때는 업로드 하지 않는다.")
+        fun `update with same thumbnailFileId does not upload thumbnail`() {
+            // Given
+            val thumbnailFileId = testFileUploader.initiateTestFileUpload("thumb.png")
+            val savedFacility =
+                facilityService.save(
+                    FacilityInstance("시설", "CODE", null, null),
+                    FacilityCreateRequest("시설", "CODE", null, null, thumbnailFileId, null, null, null),
+                )
+
+            // When & Then
+            val request = FacilityUpdateRequest("수정된 이름", null, null, thumbnailFileId, null, null, null)
+            facilityService.update(savedFacility.requiredId, request)
+
+            val updated = facilityService.findById(savedFacility.requiredId)
+            updated.thumbnailFileId shouldBe thumbnailFileId
+            updated.name shouldBe "수정된 이름"
+        }
+
+        @Test
         @DisplayName("성공: 시설 삭제 시 DB에서 소프트 삭제된다")
         fun `deleteFacility with existing id soft deletes facility`() {
             // GIVEN
@@ -494,5 +514,40 @@ class FacilityServiceTest
             updated.position?.lon shouldBe 127.5
             updated.position?.lat shouldBe 37.5
             updated.position?.locationMeta shouldBe "{'new_meta': true}"
+        }
+
+        @Test
+        @DisplayName("성공: findAllFacilities 호출 시 파일 정보가 포함된 시설 목록을 반환한다")
+        fun `findAllFacilities when facilities exist returns list with file info`() {
+            // GIVEN
+            val drawingFileId = testFileUploader.initiateTestFileUpload("drawing1.dwg")
+            val thumbnailFileId = testFileUploader.initiateTestFileUpload("thumb1.png")
+
+            val facility1 =
+                facilityService.save(
+                    FacilityInstance("시설1", "CODE1", null, null, null),
+                    FacilityCreateRequest("시설1", "CODE1", null, drawingFileId, thumbnailFileId, null, null, null),
+                )
+            val facility2 =
+                facilityService.save(
+                    FacilityInstance("시설2", "CODE2", null, null, null),
+                    FacilityCreateRequest("시설2", "CODE2", null, null, null, null, null, null),
+                )
+
+            // WHEN
+            val facilities = facilityService.findAllFacilities()
+            println(facilities)
+
+            // THEN
+            val facility1Response = facilities.find { it.id == facility1.requiredId }!!
+            val facility2Response = facilities.find { it.id == facility2.requiredId }!!
+
+            facility1Response.name shouldBe "시설1"
+            facility1Response.thumbnail.originalFileName shouldBe "thumb1.png"
+            facility1Response.drawing.originalFileName shouldBe "drawing1.dwg"
+
+            facility2Response.name shouldBe "시설2"
+            facility2Response.thumbnail.originalFileName shouldBe null
+            facility2Response.drawing.originalFileName shouldBe null
         }
     }

--- a/common/src/test/kotlin/com/pluxity/facility/FacilityServiceTest.kt
+++ b/common/src/test/kotlin/com/pluxity/facility/FacilityServiceTest.kt
@@ -536,7 +536,6 @@ class FacilityServiceTest
 
             // WHEN
             val facilities = facilityService.findAllFacilities()
-            println(facilities)
 
             // THEN
             val facility1Response = facilities.find { it.id == facility1.requiredId }!!

--- a/common/src/test/kotlin/com/pluxity/user/service/PermissionGroupServiceTest.kt
+++ b/common/src/test/kotlin/com/pluxity/user/service/PermissionGroupServiceTest.kt
@@ -128,6 +128,30 @@ internal class PermissionGroupServiceTest
                     }
                 assertThat(exception.errorCode).isEqualTo(ErrorCode.DUPLICATE_RESOURCE_ID)
             }
+
+            @Test
+            @DisplayName("실패: 요청 DTO의 ResourceType이 유효하지 않을 경우 INVALID_RESOURCE_TYPE 예외가 발생한다.")
+            fun withInvalidResourceTypeInRequest_shouldThrowException() {
+                // given
+                val invalidRequest =
+                    PermissionGroupCreateRequest(
+                        "잘못된 그룹",
+                        "설명",
+                        listOf(
+                            PermissionRequest(
+                                "INVALID-RESOURCE-TYPE",
+                                listOf("READ"),
+                            ),
+                        ),
+                    )
+
+                // when & then
+                val exception =
+                    assertThrows<CustomException> {
+                        permissionGroupService.create(invalidRequest)
+                    }
+                assertThat(exception.message).isEqualTo(ErrorCode.INVALID_RESOURCE_TYPE.getMessage().format("INVALID-RESOURCE-TYPE"))
+            }
         }
 
         @Nested

--- a/common/src/test/kotlin/com/pluxity/user/service/UserServiceKoTest.kt
+++ b/common/src/test/kotlin/com/pluxity/user/service/UserServiceKoTest.kt
@@ -15,6 +15,7 @@ import com.pluxity.user.repository.RoleRepository
 import com.pluxity.user.repository.UserRepository
 import com.pluxity.user.repository.UserRoleRepository
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -27,6 +28,8 @@ import org.springframework.security.crypto.password.PasswordEncoder
 
 class UserServiceKoTest :
     BehaviorSpec({
+        isolationMode = IsolationMode.InstancePerLeaf
+
         val userRepository: UserRepository = mockk()
         val roleRepository: RoleRepository = mockk()
         val passwordEncoder: PasswordEncoder = mockk()
@@ -181,6 +184,7 @@ class UserServiceKoTest :
                 Then("성공") {
                     val res = userService.update(user.requiredId, updateRequest)
                     res.name shouldBe updateRequest.name
+                    res.roles.size shouldBe 1
                 }
             }
         }

--- a/common/src/testFixtures/kotlin/asset/DummyEntities.kt
+++ b/common/src/testFixtures/kotlin/asset/DummyEntities.kt
@@ -1,0 +1,32 @@
+package asset
+
+import base.entity.withAudit
+import base.entity.withId
+import com.pluxity.asset.entity.Asset
+import com.pluxity.asset.entity.AssetCategory
+
+fun dummyAssetCategory(
+    id: Long? = null,
+    code: String = "category-code",
+    iconFileId: Long? = null,
+    categoryName: String = "category-name",
+) = AssetCategory(
+    code = code,
+    iconFileId = iconFileId,
+    categoryName = categoryName,
+).withId(id).withAudit()
+
+fun dummyAsset(
+    id: Long? = null,
+    name: String = "asset-name",
+    code: String = "asset-code",
+    category: AssetCategory = dummyAssetCategory(iconFileId = 1L),
+    fileId: Long? = null,
+    thumbnailFileId: Long? = null,
+) = Asset(
+    name = name,
+    code = code,
+    category = category,
+    fileId = fileId,
+    thumbnailFileId = thumbnailFileId,
+).withId(id).withAudit()

--- a/core/src/test/kotlin/com/pluxity/building/BuildingServiceKoTest.kt
+++ b/core/src/test/kotlin/com/pluxity/building/BuildingServiceKoTest.kt
@@ -12,6 +12,7 @@ import com.pluxity.global.exception.CustomException
 import facility.floor.dummyFloorResponse
 import file.dummyFileResponse
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -25,6 +26,8 @@ import org.springframework.data.repository.findByIdOrNull
 
 class BuildingServiceKoTest :
     BehaviorSpec({
+        isolationMode = IsolationMode.InstancePerLeaf
+
         val fileService: FileService = mockk()
         val facilityService: FacilityService = mockk()
         val floorService: FloorService = mockk()
@@ -121,6 +124,18 @@ class BuildingServiceKoTest :
                 Then("정상 수정") {
                     buildingService.putUpdate(building.requiredId, updateRequest)
                     building.name shouldBe updateRequest.facility.name
+                }
+            }
+            When("없는 아이디로 수정 요청") {
+                val updateRequest = dummyUpdateBuildingRequest()
+                every {
+                    repository.findByIdOrNull(any())
+                } returns null
+
+                Then("NOT_FOUND_FACILITY 예외 발생") {
+                    shouldThrowExactly<CustomException> {
+                        buildingService.putUpdate(1L, updateRequest)
+                    }.message shouldBe ErrorCode.NOT_FOUND_BUILDING.getMessage().format(1L)
                 }
             }
         }

--- a/core/src/test/kotlin/com/pluxity/building/BuildingServiceTest.kt
+++ b/core/src/test/kotlin/com/pluxity/building/BuildingServiceTest.kt
@@ -165,6 +165,24 @@ internal class BuildingServiceTest
         }
 
         @Test
+        @DisplayName("존재하지 않는 건물 ID로 건물 수정 시 예외가 발생한다.")
+        fun update_WithInvalidRequest_ThrowsCustomException() {
+            // given
+            val invalidId = 9999L
+
+            val updateRequest =
+                BuildingUpdateRequest(
+                    FacilityUpdateRequest("수정된 건물 이름", "수정된 코드", "수정된 건물 설명", null, null, null, null),
+                    emptyList(),
+                )
+
+            // when & then
+            assertThrows<CustomException> {
+                buildingService.update(invalidId, updateRequest)
+            }
+        }
+
+        @Test
         @DisplayName("건물 삭제 시 모든 이력이 삭제된다")
         fun delete() {
             // given

--- a/core/src/test/kotlin/com/pluxity/feature/service/FeatureServiceKoTest.kt
+++ b/core/src/test/kotlin/com/pluxity/feature/service/FeatureServiceKoTest.kt
@@ -477,5 +477,35 @@ class FeatureServiceKoTest :
                     verify(exactly = 1) { featureAssignment.clearFeatureFromTarget(assignDto.id) }
                 }
             }
+
+            When("할당되지 않은 CCTV 제거 시도할 때") {
+                val featureId = "test-feature-id"
+                val assignDto = FeatureAssignDto(id = "cctv-1", type = FeatureAssignType.CCTV)
+
+                every {
+                    featureAssignment.validateRevoke(assignDto.id, featureId)
+                } throws CustomException(ErrorCode.CCTV_NOT_ASSIGNED, assignDto.id)
+
+                Then("CCTV_NOT_ASSIGNED 예외 발생") {
+                    shouldThrowExactly<CustomException> {
+                        featureService.removeSomethingFromFeature(featureId, assignDto)
+                    }.errorCode shouldBe ErrorCode.CCTV_NOT_ASSIGNED
+                }
+            }
+
+            When("다른 Feature에 할당된 CCTV 제거 시도") {
+                val featureId = "test-feature-id"
+                val assignDto = FeatureAssignDto(id = "cctv-1", type = FeatureAssignType.CCTV)
+
+                every {
+                    featureAssignment.validateRevoke(assignDto.id, featureId)
+                } throws CustomException(ErrorCode.CCTV_MISMATCH)
+
+                Then("CCTV_MISMATCH 예외 발생") {
+                    shouldThrowExactly<CustomException> {
+                        featureService.removeSomethingFromFeature(featureId, assignDto)
+                    }.errorCode shouldBe ErrorCode.CCTV_MISMATCH
+                }
+            }
         }
     })

--- a/core/src/test/kotlin/com/pluxity/park/ParkServiceKoTest.kt
+++ b/core/src/test/kotlin/com/pluxity/park/ParkServiceKoTest.kt
@@ -107,6 +107,16 @@ class ParkServiceKoTest :
                     park.boundary shouldBe updateRequest.boundary
                 }
             }
+            When("없는 아이디로 업데이트 요청") {
+                Then("NOT_FOUND_PARK 예외 발생") {
+                    val searchId = 1L
+                    every { parkRepository.findByIdOrNull(searchId) } returns null
+
+                    shouldThrowExactly<CustomException> {
+                        parkService.update(searchId, dummyUpdateParkRequest())
+                    }.message shouldBe ErrorCode.NOT_FOUND_PARK.getMessage().format(searchId)
+                }
+            }
         }
 
         Given("Park 삭제를 진행할 때") {
@@ -124,6 +134,16 @@ class ParkServiceKoTest :
                     parkService.delete(park.requiredId)
                     verify(exactly = 1) { facilityService.deleteFacility(any()) }
                     slot.captured shouldBe park.id
+                }
+            }
+            When("없는 아이디로 업데이트 요청") {
+                Then("NOT_FOUND_PARK 예외 발생") {
+                    val searchId = 1L
+                    every { parkRepository.findByIdOrNull(searchId) } returns null
+
+                    shouldThrowExactly<CustomException> {
+                        parkService.delete(searchId)
+                    }.message shouldBe ErrorCode.NOT_FOUND_PARK.getMessage().format(searchId)
                 }
             }
         }

--- a/core/src/test/kotlin/com/pluxity/station/LineServiceKoTest.kt
+++ b/core/src/test/kotlin/com/pluxity/station/LineServiceKoTest.kt
@@ -129,10 +129,15 @@ class LineServiceKoTest :
             }
 
             When("유효한 요청으로 Line 수정 요청") {
-                every { lineRepository.findByNameAndIdNot(any(), any()) } returns null
+                every { lineRepository.findByNameAndIdNot(updateRequest.name!!, any()) } returns null
 
                 Then("성공") {
                     lineService.update(line.requiredId, updateRequest)
+
+                    line.name shouldBe updateRequest.name
+                    line.color shouldBe updateRequest.color
+
+                    verify(exactly = 1) { lineRepository.findByNameAndIdNot(any(), any()) }
                 }
             }
         }
@@ -150,6 +155,7 @@ class LineServiceKoTest :
                 Then("성공") {
                     lineService.delete(line.requiredId)
                     verify(exactly = 1) { lineRepository.delete(any()) }
+                    verify(exactly = 1) { stationLineService.deleteStationLine(any(), any()) }
                 }
             }
         }

--- a/core/src/test/kotlin/com/pluxity/station/StationServiceKoTest.kt
+++ b/core/src/test/kotlin/com/pluxity/station/StationServiceKoTest.kt
@@ -13,9 +13,12 @@ import com.pluxity.station.entity.dummyLine
 import com.pluxity.station.entity.dummyStation
 import facility.floor.dummyFloorResponse
 import file.dummyFileResponse
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.mockk.Called
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -28,6 +31,8 @@ import org.springframework.data.repository.findByIdOrNull
 
 class StationServiceKoTest :
     BehaviorSpec({
+        isolationMode = IsolationMode.InstancePerLeaf
+
         val fileService: FileService = mockk()
         val facilityService: FacilityService = mockk()
         val floorService: FloorService = mockk()
@@ -52,20 +57,64 @@ class StationServiceKoTest :
             )
 
         Given("Station 생성을 진행할 때") {
-            When("유효한 요청으로 Station 생성 요청") {
-                val createRequest = dummyCreateStationRequest()
-                val saved = dummyStation()
-                val line = dummyLine()
+            val createRequest = dummyCreateStationRequest()
+            val saved = dummyStation()
+            val line = dummyLine()
 
-                every { facilityService.save(any<Facility>(), createRequest.facility) } returns saved
-                every { floorService.save(any(), any()) } just runs
-                every { lineService.findLineById(any()) } returns line
-                every { stationLineService.save(any(), any()) } just runs
-                every { stationCodeService.save(any(), any()) } just runs
+            // Mock 세팅
+            every { facilityService.save(any<Station>(), any()) } returns saved
+            every { floorService.save(any(), any()) } just runs
+            every { lineService.findLineById(any()) } returns line
+            every { stationLineService.save(any(), any()) } just runs
+            every { stationCodeService.save(any(), any()) } just runs
 
-                Then("성공") {
-                    val saveId = stationService.save(createRequest)
+            When("유효한 요청으로 Station 생성 요청을 보내면") {
+                val saveId = stationService.save(createRequest)
+
+                Then("저장된 ID가 반환된다") {
                     saveId shouldBe saved.id
+                }
+
+                Then("연관된 서비스들에 저장 요청을 전달한다.") {
+                    verify(exactly = 1) { facilityService.save(any(), any()) }
+                    verify(exactly = 1) { floorService.save(any(), any()) }
+                    verify(exactly = 1) { stationLineService.save(any(), any()) }
+                    verify(exactly = 1) { stationCodeService.save(any(), any()) }
+                }
+            }
+            When("시설 저장 중 중복 에러가 발생하면") {
+                every { facilityService.save(any(), any()) } throws
+                    CustomException(ErrorCode.DUPLICATE_FACILITY_CODE)
+
+                Then("더 이상 프로세스를 진행하지 않고 예외를 상위로 던진다") {
+                    shouldThrow<CustomException> {
+                        stationService.save(createRequest)
+                    }
+
+                    verify { floorService wasNot Called }
+                    verify { stationLineService wasNot Called }
+                }
+            }
+            When("연관된 노선이 여러 개 포함된 경우") {
+                val multipleLineRequest = createRequest.copy(lineIds = listOf(1L, 2L, 3L))
+
+                stationService.save(multipleLineRequest)
+
+                Then("노선 정보 조회 및 저장이 개수만큼 반복 호출된다") {
+                    verify(exactly = 3) { lineService.findLineById(any()) }
+                    verify(exactly = 3) { stationLineService.save(any(), any()) }
+                }
+            }
+            When("노선 ID와 스테이션 코드가 없는 최소 정보로 생성 요청을 보내면") {
+                val minimalRequest = createRequest.copy(lineIds = emptyList(), stationCodes = emptyList())
+
+                stationService.save(minimalRequest)
+
+                Then("기본 시설과 층 정보만 저장하고 종료된다") {
+                    verify(exactly = 1) { facilityService.save(any(), any()) }
+                    verify(exactly = 1) { floorService.save(any(), any()) }
+                    verify { stationLineService wasNot Called }
+                    verify { stationCodeService wasNot Called }
                 }
             }
         }
@@ -93,8 +142,12 @@ class StationServiceKoTest :
                     stationLineService.findLineMapByStationIds(any())
                 } returns mapOf(station to listOf(1L))
 
+                val result = stationService.findAll()
+
                 Then("정상 조회") {
-                    stationService.findAll().size shouldBe 1
+                    result.size shouldBe 1
+                    result.first().facility.name shouldBe station.name
+                    result.first().floors.size shouldBe 1
                 }
             }
         }


### PR DESCRIPTION
## 요약
 테스트 케이스 추가

  

## 변경사항 🏗️  
- FacilityPathKoTest 생성
  - findById, update, delete 메서드의 예외 처리 및 정상 동작 테스트 코드 작성
- FacilityHistoryKotTest 생성
  - findByFacilityId 동작을 검증하는 테스트 코드 작성
- PermissionGroupServiceTest 케이스 추가
  - 요청 DTO의 ResourceType이 유효하지 않을 경우 INVALID_RESOURCE_TYPE 예외가 발생하는 테스트 케이스 추가
- AssetCategoryServiceTest 케이스 추가
  - 전체 카테고리가 없을 때 빈 리스트를 반환하는 테스트 케이스 추가
  - 카테고리 수정 시 코드 중복 체크를 건너뛰는 테스트 케이스 추가
  - 썸네일을 null로 변경하는 테스트 케이스 추가
- FeatureServiceKoTest 케이스 추가
  - 할당되지 않은 CCTV 제거 시도 시 CCTV_NOT_ASSIGNED 예외 발생 테스트 케이스 추가
  - 다른 Feature에 할당된 CCTV 제거 시도 시 CCTV_MISMATCH 예외 발생 테스트 케이스 추가
- FacilityServiceTest 케이스 추가
  - thumbnailFileId가 동일한 경우 썸네일 업로드가 발생하지 않는지 검증하는 테스트 추가
  - findAllFacilities 호출 시 파일 정보가 포함된 시설 목록 반환을 검증하는 테스트 추가
- AuthenticationServiceTest 케이스 추가
  - 리프레시 토큰 없이 요청 시 INVALID_REFRESH_TOKEN 예외 발생 테스트 케이스 추가
- BuildingServiceTest 케이스 추가
  - 존재하지 않는 건물 ID로 수정 시 예외 발생 테스트 케이스 추가
 

<!-- 변경 사항에 대해서 기재 필요 -->
### Checklist 📋
## 코드 변경 사항   
- [x] PR 설명에 변경 사항을 명확히 기재했습니다.  
